### PR TITLE
JPA Polymorphism을 활용한 코드 리팩토링 예시 소개

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     idea
+    `java-test-fixtures`
     kotlin("jvm") version Ver.kotlin
     kotlin("kapt") version Ver.kotlin
 
@@ -31,6 +32,7 @@ subprojects {
     version = rootProject.version
 
     apply(plugin = Plugins.idea)
+    apply(plugin = Plugins.javaTestFixtures)
     apply(plugin = Plugins.kotlin)
     apply(plugin = Plugins.kotlinJpa)
     apply(plugin = Plugins.kotlinKapt)

--- a/buildSrc/src/main/kotlin/DependencyHandlerScopeExtensions.kt
+++ b/buildSrc/src/main/kotlin/DependencyHandlerScopeExtensions.kt
@@ -1,5 +1,14 @@
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 
+fun DependencyHandlerScope.flyway(
+    module: String,
+    version: String = Ver.flyway,
+): String = "org.flywaydb:flyway-$module:$version"
+
+fun DependencyHandlerScope.postgres(
+    version: String = Ver.postgres,
+): String = "org.postgresql:postgresql:$version"
+
 fun DependencyHandlerScope.spring(
     module: String,
 ): String = "org.springframework:spring-$module"

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -1,6 +1,7 @@
 object Plugins {
 
     const val idea = "idea"
+    const val javaTestFixtures = "java-test-fixtures"
     const val kotlin = "kotlin"
     const val kotlinJpa = "org.jetbrains.kotlin.plugin.jpa"
     const val kotlinKapt = "org.jetbrains.kotlin.kapt"

--- a/buildSrc/src/main/kotlin/Ver.kt
+++ b/buildSrc/src/main/kotlin/Ver.kt
@@ -1,8 +1,10 @@
 object Ver {
-    
+
+    const val flyway: String = "8.5.12"
     const val kotlin = "1.6.21"
     const val ktlint = "0.45.2"
     const val ktlintPlugin = "10.2.1"
+    const val postgres = "42.3.8"
     const val springBoot = "2.7.7"
     const val springDependencyManagement = "1.1.4"
     const val testContainers = "1.19.4"

--- a/examples/examples-jpa-polymorphism/build.gradle.kts
+++ b/examples/examples-jpa-polymorphism/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":infra-jpa"))
+    testImplementation(testFixtures(project(":infra-jpa")))
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/Constants.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/Constants.kt
@@ -1,0 +1,6 @@
+package com.github.wonsim02.examples.jpapolymorphism
+
+object Constants {
+
+    const val SCHEMA_NAME = "public"
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/ExamplesJpaPolymorphismEntity1Configuration.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/ExamplesJpaPolymorphismEntity1Configuration.kt
@@ -1,0 +1,18 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@Configuration
+@ComponentScan(
+    basePackages = ["com.github.wonsim02.examples.jpapolymorphism.entity1"],
+)
+@EntityScan(
+    basePackages = ["com.github.wonsim02.examples.jpapolymorphism.entity1"],
+)
+@EnableJpaRepositories(
+    basePackages = ["com.github.wonsim02.examples.jpapolymorphism.entity1"],
+)
+class ExamplesJpaPolymorphismEntity1Configuration

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaOrderEntity.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaOrderEntity.kt
@@ -1,0 +1,47 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import com.github.wonsim02.examples.jpapolymorphism.Constants
+import com.github.wonsim02.examples.jpapolymorphism.model.Order
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+/**
+ * [Order]에 대한 JPA 엔티티.
+ * [Order] 구현체가 공통으로 가지는 속성인 [Order.id], [Order.userId] 및 [Order.type]에 대응되는 열(Column)만을 가지고 있다.
+ */
+@Entity(name = JpaOrderEntity.ENTITY_NAME)
+@Table(
+    schema = Constants.SCHEMA_NAME,
+    name = JpaOrderEntity.TABLE_NAME,
+)
+open class JpaOrderEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "type")
+    @Enumerated(value = EnumType.STRING)
+    val type: Order.Type,
+) {
+
+    constructor(order: Order) : this(
+        id = order.id,
+        userId = order.userId,
+        type = order.type,
+    )
+
+    companion object {
+
+        const val ENTITY_NAME = "JpaOrderEntity"
+        const val TABLE_NAME = "order"
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaOrderEntityRepository.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaOrderEntityRepository.kt
@@ -1,0 +1,5 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaOrderEntityRepository : JpaRepository<JpaOrderEntity, Long>

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSinglePaymentOrderEntity.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSinglePaymentOrderEntity.kt
@@ -1,0 +1,49 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import com.github.wonsim02.examples.jpapolymorphism.Constants
+import com.github.wonsim02.examples.jpapolymorphism.model.SinglePaymentOrder
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+/**
+ * [SinglePaymentOrder]의 추가적인 속성에 대한 JPA 엔티티.
+ * [JpaOrderEntity.id]와 값을 공유하는 [id] 및 [SinglePaymentOrder]의 추가적인 속성에 대한 열(Column)만을 가지고 있다.
+ */
+@Entity(name = JpaSinglePaymentOrderEntity.ENTITY_NAME)
+@Table(
+    schema = Constants.SCHEMA_NAME,
+    name = JpaSinglePaymentOrderEntity.TABLE_NAME,
+)
+open class JpaSinglePaymentOrderEntity(
+    @Id
+    val id: Long,
+
+    @Column(name = "single_payment_product_id")
+    val singlePaymentProductId: Long,
+
+    @Column(name = "paid_amount")
+    val paidAmount: Int,
+
+    @Column(name = "paid_at")
+    val paidAt: Instant,
+) {
+
+    constructor(
+        singlePaymentOrder: SinglePaymentOrder,
+        newId: Long? = null,
+    ) : this(
+        id = newId ?: singlePaymentOrder.id,
+        singlePaymentProductId = singlePaymentOrder.singlePaymentProductId,
+        paidAmount = singlePaymentOrder.paidAmount,
+        paidAt = singlePaymentOrder.paidAt,
+    )
+
+    companion object {
+
+        const val ENTITY_NAME = "JpaSinglePaymentOrderEntity"
+        const val TABLE_NAME = "order_single_payment"
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSinglePaymentOrderEntityRepository.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSinglePaymentOrderEntityRepository.kt
@@ -1,0 +1,5 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaSinglePaymentOrderEntityRepository : JpaRepository<JpaSinglePaymentOrderEntity, Long>

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSubscriptionOrderEntity.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSubscriptionOrderEntity.kt
@@ -1,0 +1,49 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import com.github.wonsim02.examples.jpapolymorphism.Constants
+import com.github.wonsim02.examples.jpapolymorphism.model.SubscriptionOrder
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+/**
+ * [SubscriptionOrder]의 추가적인 속성에 대한 JPA 엔티티.
+ * [JpaOrderEntity.id]와 값을 공유하는 [id] 및 [SubscriptionOrder]의 추가적인 속성에 대한 열(Column)만을 가지고 있다.
+ */
+@Entity(name = JpaSubscriptionOrderEntity.ENTITY_NAME)
+@Table(
+    schema = Constants.SCHEMA_NAME,
+    name = JpaSubscriptionOrderEntity.TABLE_NAME,
+)
+open class JpaSubscriptionOrderEntity(
+    @Id
+    val id: Long,
+
+    @Column(name = "subscription_product_id")
+    val subscriptionProductId: Long,
+
+    @Column(name = "payment_amount_per_month")
+    val paymentAmountPerMonth: Int,
+
+    @Column(name = "last_paid_at")
+    val lastPaidAt: Instant,
+) {
+
+    constructor(
+        subscriptionOrder: SubscriptionOrder,
+        newId: Long? = null,
+    ) : this(
+        id = newId ?: subscriptionOrder.id,
+        subscriptionProductId = subscriptionOrder.subscriptionProductId,
+        paymentAmountPerMonth = subscriptionOrder.paymentAmountPerMonth,
+        lastPaidAt = subscriptionOrder.lastPaidAt,
+    )
+
+    companion object {
+
+        const val ENTITY_NAME = "JpaSubscriptionOrderEntity"
+        const val TABLE_NAME = "order_subscription"
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSubscriptionOrderEntityRepository.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/JpaSubscriptionOrderEntityRepository.kt
@@ -1,0 +1,5 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaSubscriptionOrderEntityRepository : JpaRepository<JpaSubscriptionOrderEntity, Long>

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/OrderRepositoryImpl1.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity1/OrderRepositoryImpl1.kt
@@ -1,0 +1,109 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity1
+
+import com.github.wonsim02.examples.jpapolymorphism.model.Order
+import com.github.wonsim02.examples.jpapolymorphism.model.OrderRepository
+import com.github.wonsim02.examples.jpapolymorphism.model.SinglePaymentOrder
+import com.github.wonsim02.examples.jpapolymorphism.model.SubscriptionOrder
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 모든 [Order]의 구현체가 공유하는 속성 및 각 [Order] 구현체 별로 차별화되는 속성이 별도 테이블의 열(Column)로 저장되어 있을 때의
+ * [OrderRepository] 구현체.
+ * - [findById] 시에는 우선 [JpaOrderEntity]를 조회한 다음 [JpaOrderEntity.type]으로부터 [JpaSinglePaymentOrderEntity] 혹은
+ *  [JpaSubscriptionOrderEntity]를 조회한다.
+ * - [save] 시에는 우선 [JpaOrderEntity]를 저장한 다음 새로 생성된 [JpaOrderEntity.id]를 이용하여 [JpaSinglePaymentOrderEntity]
+ *  혹은 [JpaSubscriptionOrderEntity]를 생성 및 저장한다.
+ */
+@Repository
+class OrderRepositoryImpl1(
+    private val jpaOrderRepo: JpaOrderEntityRepository,
+    private val jpaSinglePaymentOrderRepo: JpaSinglePaymentOrderEntityRepository,
+    private val jpaSubscriptionOrderRepo: JpaSubscriptionOrderEntityRepository,
+) : OrderRepository {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override fun findById(id: Long): Order? {
+        val jpaOrderEntity = jpaOrderRepo
+            .findByIdOrNull(id)
+            ?: return null
+
+        return when (jpaOrderEntity.type) {
+            Order.Type.SINGLE_PAYMENT -> {
+                val jpaSinglePaymentOrderEntity = jpaSinglePaymentOrderRepo
+                    .findById(id)
+                    .orElseGet {
+                        logger.warn("No JpaSinglePaymentOrderEntity for id={} found.", id)
+                        null
+                    }
+                    ?: return null
+                toSinglePaymentOrder(jpaOrderEntity, jpaSinglePaymentOrderEntity)
+            }
+            Order.Type.SUBSCRIPTION -> {
+                val jpaSubscriptionOrderEntity = jpaSubscriptionOrderRepo
+                    .findById(id)
+                    .orElseGet {
+                        logger.warn("No JpaSubscriptionOrderEntity for id={} found.", id)
+                        null
+                    }
+                    ?: return null
+                toSubscriptionOrder(jpaOrderEntity, jpaSubscriptionOrderEntity)
+            }
+        }
+    }
+
+    @Transactional
+    override fun save(order: Order): Order {
+        val jpaOrderEntity = jpaOrderRepo.save(JpaOrderEntity(order))
+
+        return when (order) {
+            is SinglePaymentOrder -> {
+                val jpaSinglePaymentOrderEntity = jpaSinglePaymentOrderRepo.save(
+                    JpaSinglePaymentOrderEntity(
+                        singlePaymentOrder = order,
+                        newId = jpaOrderEntity.id,
+                    )
+                )
+                toSinglePaymentOrder(jpaOrderEntity, jpaSinglePaymentOrderEntity)
+            }
+            is SubscriptionOrder -> {
+                val jpaSubscriptionOrderEntity = jpaSubscriptionOrderRepo.save(
+                    JpaSubscriptionOrderEntity(
+                        subscriptionOrder = order,
+                        newId = jpaOrderEntity.id,
+                    )
+                )
+                toSubscriptionOrder(jpaOrderEntity, jpaSubscriptionOrderEntity)
+            }
+        }
+    }
+
+    private fun toSinglePaymentOrder(
+        jpaOrderEntity: JpaOrderEntity,
+        jpaSinglePaymentOrderEntity: JpaSinglePaymentOrderEntity,
+    ): SinglePaymentOrder {
+        return SinglePaymentOrder(
+            id = jpaOrderEntity.id,
+            userId = jpaOrderEntity.userId,
+            singlePaymentProductId = jpaSinglePaymentOrderEntity.singlePaymentProductId,
+            paidAmount = jpaSinglePaymentOrderEntity.paidAmount,
+            paidAt = jpaSinglePaymentOrderEntity.paidAt,
+        )
+    }
+
+    private fun toSubscriptionOrder(
+        jpaOrderEntity: JpaOrderEntity,
+        jpaSubscriptionOrderEntity: JpaSubscriptionOrderEntity,
+    ): SubscriptionOrder {
+        return SubscriptionOrder(
+            id = jpaOrderEntity.id,
+            userId = jpaOrderEntity.userId,
+            subscriptionProductId = jpaSubscriptionOrderEntity.subscriptionProductId,
+            paymentAmountPerMonth = jpaSubscriptionOrderEntity.paymentAmountPerMonth,
+            lastPaidAt = jpaSubscriptionOrderEntity.lastPaidAt,
+        )
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/ExamplesJpaPolymorphismEntity2Configuration.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/ExamplesJpaPolymorphismEntity2Configuration.kt
@@ -1,0 +1,18 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity2
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@Configuration
+@ComponentScan(
+    basePackages = ["com.github.wonsim02.examples.jpapolymorphism.entity2"],
+)
+@EntityScan(
+    basePackages = ["com.github.wonsim02.examples.jpapolymorphism.entity2"],
+)
+@EnableJpaRepositories(
+    basePackages = ["com.github.wonsim02.examples.jpapolymorphism.entity2"],
+)
+class ExamplesJpaPolymorphismEntity2Configuration

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaOrderEntity.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaOrderEntity.kt
@@ -1,0 +1,53 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity2
+
+import com.github.wonsim02.examples.jpapolymorphism.Constants
+import com.github.wonsim02.examples.jpapolymorphism.model.Order
+import javax.persistence.Column
+import javax.persistence.DiscriminatorColumn
+import javax.persistence.DiscriminatorType
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Inheritance
+import javax.persistence.InheritanceType
+import javax.persistence.Table
+
+/**
+ * [JPA Polymorphism](https://www.baeldung.com/hibernate-inheritance#joined-table)을 이용한 [Order]에 대한 JPA 엔티티.
+ * [Order.type]에 대응되는 `type` 열은 판별자(Discriminator) 열로 사용된다.
+ */
+@Entity(name = JpaOrderEntity.ENTITY_NAME)
+@Table(
+    schema = Constants.SCHEMA_NAME,
+    name = JpaOrderEntity.TABLE_NAME,
+)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(
+    name = JpaOrderEntity.DISCRIMINATOR_COLUMN,
+    discriminatorType = DiscriminatorType.STRING,
+)
+sealed class JpaOrderEntity<ORDER : Order>(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Column(name = "user_id")
+    val userId: Long,
+) {
+
+    constructor(order: Order) : this(
+        id = order.id,
+        userId = order.userId,
+    )
+
+    abstract fun toOrder(): ORDER
+
+    companion object {
+
+        const val ENTITY_NAME = "JpaOrderEntity"
+        const val TABLE_NAME = "order"
+
+        const val DISCRIMINATOR_COLUMN = "type"
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaOrderEntityRepository.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaOrderEntityRepository.kt
@@ -1,0 +1,5 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity2
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaOrderEntityRepository : JpaRepository<JpaOrderEntity<*>, Long>

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaSinglePaymentOrderEntity.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaSinglePaymentOrderEntity.kt
@@ -1,0 +1,63 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity2
+
+import com.github.wonsim02.examples.jpapolymorphism.Constants
+import com.github.wonsim02.examples.jpapolymorphism.model.Order
+import com.github.wonsim02.examples.jpapolymorphism.model.SinglePaymentOrder
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.DiscriminatorValue
+import javax.persistence.Entity
+import javax.persistence.Table
+
+/**
+ * [SinglePaymentOrder]에 대한 JPA 엔티티.
+ * - [JpaOrderEntity]의 `type` 열의 값은 [Order.Type.SINGLE_PAYMENT]와 일치한다.
+ * - [SinglePaymentOrder.id]에 대응되는 [id] 열은 [JpaOrderEntity]로부터 상속받는다.
+ */
+@Entity(name = JpaSinglePaymentOrderEntity.ENTITY_NAME)
+@Table(
+    schema = Constants.SCHEMA_NAME,
+    name = JpaSinglePaymentOrderEntity.TABLE_NAME,
+)
+@DiscriminatorValue(value = JpaSinglePaymentOrderEntity.DISCRIMINATOR_VALUE)
+open class JpaSinglePaymentOrderEntity private constructor(
+    order: Order,
+
+    @Column(name = "single_payment_product_id")
+    val singlePaymentProductId: Long,
+
+    @Column(name = "paid_amount")
+    val paidAmount: Int,
+
+    @Column(name = "paid_at")
+    val paidAt: Instant,
+) : JpaOrderEntity<SinglePaymentOrder>(order) {
+
+    constructor(singlePaymentOrder: SinglePaymentOrder) : this(
+        order = singlePaymentOrder,
+        singlePaymentProductId = singlePaymentOrder.singlePaymentProductId,
+        paidAmount = singlePaymentOrder.paidAmount,
+        paidAt = singlePaymentOrder.paidAt,
+    )
+
+    override fun toOrder(): SinglePaymentOrder {
+        return SinglePaymentOrder(
+            id = id,
+            userId = userId,
+            singlePaymentProductId = singlePaymentProductId,
+            paidAmount = paidAmount,
+            paidAt = paidAt,
+        )
+    }
+
+    companion object {
+
+        const val ENTITY_NAME = "JpaSinglePaymentOrderEntity"
+        const val TABLE_NAME = "order_single_payment"
+        const val DISCRIMINATOR_VALUE = "SINGLE_PAYMENT"
+
+        init {
+            assert(Order.Type.valueOf(DISCRIMINATOR_VALUE) == Order.Type.SINGLE_PAYMENT)
+        }
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaSubscriptionOrderEntity.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/JpaSubscriptionOrderEntity.kt
@@ -1,0 +1,63 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity2
+
+import com.github.wonsim02.examples.jpapolymorphism.Constants
+import com.github.wonsim02.examples.jpapolymorphism.model.Order
+import com.github.wonsim02.examples.jpapolymorphism.model.SubscriptionOrder
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.DiscriminatorValue
+import javax.persistence.Entity
+import javax.persistence.Table
+
+/**
+ * [SubscriptionOrder]에 대한 JPA 엔티티.
+ * - [JpaOrderEntity]의 `type` 열의 값은 [Order.Type.SUBSCRIPTION]와 일치한다.
+ * - [SubscriptionOrder.id]에 대응되는 [id] 열은 [JpaOrderEntity]로부터 상속받는다.
+ */
+@Entity(name = JpaSubscriptionOrderEntity.ENTITY_NAME)
+@Table(
+    schema = Constants.SCHEMA_NAME,
+    name = JpaSubscriptionOrderEntity.TABLE_NAME,
+)
+@DiscriminatorValue(value = JpaSubscriptionOrderEntity.DISCRIMINATOR_VALUE)
+open class JpaSubscriptionOrderEntity private constructor(
+    order: Order,
+
+    @Column(name = "subscription_product_id")
+    val subscriptionProductId: Long,
+
+    @Column(name = "payment_amount_per_month")
+    val paymentAmountPerMonth: Int,
+
+    @Column(name = "last_paid_at")
+    val lastPaidAt: Instant,
+) : JpaOrderEntity<SubscriptionOrder>(order) {
+
+    constructor(subscriptionOrder: SubscriptionOrder) : this(
+        order = subscriptionOrder,
+        subscriptionProductId = subscriptionOrder.subscriptionProductId,
+        paymentAmountPerMonth = subscriptionOrder.paymentAmountPerMonth,
+        lastPaidAt = subscriptionOrder.lastPaidAt,
+    )
+
+    override fun toOrder(): SubscriptionOrder {
+        return SubscriptionOrder(
+            id = id,
+            userId = userId,
+            subscriptionProductId = subscriptionProductId,
+            paymentAmountPerMonth = paymentAmountPerMonth,
+            lastPaidAt = lastPaidAt,
+        )
+    }
+
+    companion object {
+
+        const val ENTITY_NAME = "JpaSubscriptionOrderEntity"
+        const val TABLE_NAME = "order_subscription"
+        const val DISCRIMINATOR_VALUE = "SUBSCRIPTION"
+
+        init {
+            assert(Order.Type.valueOf(DISCRIMINATOR_VALUE) == Order.Type.SUBSCRIPTION)
+        }
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/OrderRepositoryImpl2.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/entity2/OrderRepositoryImpl2.kt
@@ -1,0 +1,33 @@
+package com.github.wonsim02.examples.jpapolymorphism.entity2
+
+import com.github.wonsim02.examples.jpapolymorphism.model.Order
+import com.github.wonsim02.examples.jpapolymorphism.model.OrderRepository
+import com.github.wonsim02.examples.jpapolymorphism.model.SinglePaymentOrder
+import com.github.wonsim02.examples.jpapolymorphism.model.SubscriptionOrder
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+/**
+ * [Order] 및 [Order]의 서브클래스에 대한 JPA 엔티티가 [JPA Polymorphism](https://www.baeldung.com/hibernate-inheritance#joined-table)를
+ * 이용하여 작성되었을 때의 [OrderRepository] 구현체.
+ * [com.github.wonsim02.examples.jpapolymorphism.entity1.OrderRepositoryImpl1]의 구현에 비해 훨씬 간결하다.
+ */
+@Repository
+class OrderRepositoryImpl2(
+    private val jpaOrderRepo: JpaOrderEntityRepository,
+) : OrderRepository {
+
+    override fun findById(id: Long): Order? {
+        return jpaOrderRepo
+            .findByIdOrNull(id)
+            ?.toOrder()
+    }
+
+    override fun save(order: Order): Order {
+        val jpaOrderEntity = when (order) {
+            is SinglePaymentOrder -> JpaSinglePaymentOrderEntity(order)
+            is SubscriptionOrder -> JpaSubscriptionOrderEntity(order)
+        }
+        return jpaOrderRepo.save(jpaOrderEntity).toOrder()
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/Order.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/Order.kt
@@ -1,0 +1,18 @@
+package com.github.wonsim02.examples.jpapolymorphism.model
+
+/**
+ * 상품 결제를 나타내는 모델.
+ * 공통된 속성으로 [id], [userId] 및 [type]을 가진다.
+ */
+sealed class Order {
+
+    abstract val id: Long
+    abstract val userId: Long
+    abstract val type: Type
+
+    enum class Type {
+
+        SINGLE_PAYMENT,
+        SUBSCRIPTION,
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/OrderRepository.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/OrderRepository.kt
@@ -1,0 +1,12 @@
+package com.github.wonsim02.examples.jpapolymorphism.model
+
+/**
+ * [Order]에 대한 리포지토리.
+ * [Order]에 대응되는 JPA 엔티티 정의에 따라 구현 방식이 달라진다.
+ */
+interface OrderRepository {
+
+    fun findById(id: Long): Order?
+
+    fun save(order: Order): Order
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/SinglePaymentOrder.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/SinglePaymentOrder.kt
@@ -1,0 +1,19 @@
+package com.github.wonsim02.examples.jpapolymorphism.model
+
+import java.time.Instant
+
+/**
+ * 단건 결제를 나타내는 [Order]의 구현체.
+ * - [type]의 값은 [Order.Type.SINGLE_PAYMENT]으로 고정이다.
+ * - [singlePaymentProductId], [paidAmount] 및 [paidAt]을 추가적인 속성으로 가진다.
+ */
+data class SinglePaymentOrder(
+    override val id: Long = 0L,
+    override val userId: Long,
+    val singlePaymentProductId: Long,
+    val paidAmount: Int,
+    val paidAt: Instant,
+) : Order() {
+
+    override val type = Type.SINGLE_PAYMENT
+}

--- a/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/SubscriptionOrder.kt
+++ b/examples/examples-jpa-polymorphism/src/main/kotlin/com/github/wonsim02/examples/jpapolymorphism/model/SubscriptionOrder.kt
@@ -1,0 +1,19 @@
+package com.github.wonsim02.examples.jpapolymorphism.model
+
+import java.time.Instant
+
+/**
+ * 구독 결제를 나타내는 [Order]의 구현체.
+ * - [type]의 값은 [Order.Type.SUBSCRIPTION]으로 고정이다.
+ * - [subscriptionProductId], [paymentAmountPerMonth] 및 [lastPaidAt]을 추가적인 속성으로 가진다.
+ */
+data class SubscriptionOrder(
+    override val id: Long = 0L,
+    override val userId: Long,
+    val subscriptionProductId: Long,
+    val paymentAmountPerMonth: Int,
+    val lastPaidAt: Instant,
+) : Order() {
+
+    override val type = Type.SUBSCRIPTION
+}

--- a/examples/examples-jpa-polymorphism/src/test/kotlin/com/github/wonsim02/examples/jpapolymorphism/App1.kt
+++ b/examples/examples-jpa-polymorphism/src/test/kotlin/com/github/wonsim02/examples/jpapolymorphism/App1.kt
@@ -1,0 +1,11 @@
+package com.github.wonsim02.examples.jpapolymorphism
+
+import com.github.wonsim02.examples.jpapolymorphism.entity1.ExamplesJpaPolymorphismEntity1Configuration
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.context.annotation.Import
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(ExamplesJpaPolymorphismEntity1Configuration::class)
+class App1

--- a/examples/examples-jpa-polymorphism/src/test/kotlin/com/github/wonsim02/examples/jpapolymorphism/App2.kt
+++ b/examples/examples-jpa-polymorphism/src/test/kotlin/com/github/wonsim02/examples/jpapolymorphism/App2.kt
@@ -1,0 +1,11 @@
+package com.github.wonsim02.examples.jpapolymorphism
+
+import com.github.wonsim02.examples.jpapolymorphism.entity2.ExamplesJpaPolymorphismEntity2Configuration
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.context.annotation.Import
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(ExamplesJpaPolymorphismEntity2Configuration::class)
+class App2

--- a/examples/examples-jpa-polymorphism/src/test/kotlin/com/github/wonsim02/examples/jpapolymorphism/JpaPolymorphismExample.kt
+++ b/examples/examples-jpa-polymorphism/src/test/kotlin/com/github/wonsim02/examples/jpapolymorphism/JpaPolymorphismExample.kt
@@ -1,0 +1,68 @@
+package com.github.wonsim02.examples.jpapolymorphism
+
+import com.github.wonsim02.examples.jpapolymorphism.entity1.ExamplesJpaPolymorphismEntity1Configuration
+import com.github.wonsim02.examples.jpapolymorphism.entity2.ExamplesJpaPolymorphismEntity2Configuration
+import com.github.wonsim02.examples.jpapolymorphism.model.OrderRepository
+import com.github.wonsim02.examples.jpapolymorphism.model.SinglePaymentOrder
+import com.github.wonsim02.examples.jpapolymorphism.model.SubscriptionOrder
+import com.github.wonsim02.infra.jpa.CustomPostgresqlContainer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.boot.ExitCodeGenerator
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.runApplication
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.Instant
+
+/**
+ * [ExamplesJpaPolymorphismEntity1Configuration]의 엔티티 정의를 따라 DB에 저장된 [SinglePaymentOrder] 및 [SubscriptionOrder]가
+ * [ExamplesJpaPolymorphismEntity2Configuration]의 엔티티 정의를 따랐을 때 DB로부터 잘 조회되는지 검사한다.
+ */
+@Testcontainers
+class JpaPolymorphismExample {
+
+    @Test
+    fun `JPA polymorphism usage for simplification of OrderRepository implementation`() {
+        val app1 = runApplication<App1>(*testContainer.provideTestContainerProperties())
+        val orderRepo1 = app1.getBean(OrderRepository::class.java)
+        val order1 = orderRepo1.save(
+            SinglePaymentOrder(
+                id = 0L,
+                userId = 1L,
+                singlePaymentProductId = 1L,
+                paidAmount = 10000,
+                paidAt = Instant.now(),
+            )
+        )
+        val order2 = orderRepo1.save(
+            SubscriptionOrder(
+                id = 0L,
+                userId = 2L,
+                subscriptionProductId = 2L,
+                paymentAmountPerMonth = 9990,
+                lastPaidAt = Instant.now(),
+            )
+        )
+        SpringApplication.exit(app1, ExitCodeGenerator { 0 })
+
+        val app2 = runApplication<App2>(*testContainer.provideTestContainerProperties())
+        val orderRepo2 = app2.getBean(OrderRepository::class.java)
+        val foundOrder1 = assertDoesNotThrow { orderRepo2.findById(order1.id)!! }
+        val foundOrder2 = assertDoesNotThrow { orderRepo2.findById(order2.id)!! }
+        assertEquals(order1, foundOrder1)
+        assertEquals(order2, foundOrder2)
+        SpringApplication.exit(app2, ExitCodeGenerator { 0 })
+    }
+
+    companion object {
+
+        @Container
+        val testContainer = CustomPostgresqlContainer(
+            database = "database",
+            username = "username",
+            password = "password",
+        )
+    }
+}

--- a/examples/examples-jpa-polymorphism/src/test/resources/application.yml
+++ b/examples/examples-jpa-polymorphism/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  flyway:
+    schemas: public
+  jpa:
+    show-sql: true

--- a/examples/examples-jpa-polymorphism/src/test/resources/db/migration/V0.0.0__init.sql
+++ b/examples/examples-jpa-polymorphism/src/test/resources/db/migration/V0.0.0__init.sql
@@ -1,0 +1,21 @@
+create schema if not exists public;
+
+create table if not exists public.order(
+    id      bigserial primary key,
+    user_id bigint not null,
+    type    text not null
+);
+
+create table if not exists public.order_single_payment(
+    id                          bigint not null primary key,
+    single_payment_product_id   bigint not null,
+    paid_amount                 int not null,
+    paid_at                     timestamptz not null
+);
+
+create table if not exists public.order_subscription(
+    id                          bigint not null primary key,
+    subscription_product_id     bigint not null,
+    payment_amount_per_month    int not null,
+    last_paid_at                timestamptz not null
+);

--- a/infra-jpa/build.gradle.kts
+++ b/infra-jpa/build.gradle.kts
@@ -1,0 +1,11 @@
+dependencies {
+    api(springBoot("starter-data-jpa"))
+    runtimeOnly(flyway("core"))
+    runtimeOnly(postgres())
+    implementation(project(":common"))
+
+    testFixturesApi(platform(testContainersBom()))
+    testFixturesApi(springBoot("starter-test"))
+    testFixturesApi(testContainers("junit-jupiter"))
+    testFixturesApi(testContainers("postgresql"))
+}

--- a/infra-jpa/src/main/kotlin/com/github/wonsim02/infra/jpa/config/InfraJpaConfiguration.kt
+++ b/infra-jpa/src/main/kotlin/com/github/wonsim02/infra/jpa/config/InfraJpaConfiguration.kt
@@ -1,0 +1,13 @@
+package com.github.wonsim02.infra.jpa.config
+
+import com.github.womsim02.common.spring.ProfileAwarePropertySource
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ProfileAwarePropertySource(
+    locations = [
+        "/infra-jpa-config.yml",
+        "/infra-jpa-config-*.yml",
+    ],
+)
+class InfraJpaConfiguration

--- a/infra-jpa/src/main/resources/META-INF/spring.factories
+++ b/infra-jpa/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.github.wonsim02.infra.jpa.config.InfraJpaConfiguration

--- a/infra-jpa/src/main/resources/infra-jpa-config.yml
+++ b/infra-jpa/src/main/resources/infra-jpa-config.yml
@@ -1,0 +1,23 @@
+spring:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${CONF_RDB_HOST}:${CONF_RDB_PORT}/${CONF_RDB_DATABASE}
+    username: ${CONF_RDB_USERNAME}
+    password: ${CONF_RDB_PASSWORD}
+    hikari:
+      minimum-idle: 10
+      idle-timeout: 30000
+      connection-timeout: 30000
+      connection-test-query: SELECT 1
+      max-lifetime: 2000000
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate.jdbc.batch_size: 10
+      hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS: 50
+      hibernate.query.plan_cache_max_size: 256

--- a/infra-jpa/src/testFixtures/kotlin/com/github/wonsim02/infra/jpa/CustomPostgresqlContainer.kt
+++ b/infra-jpa/src/testFixtures/kotlin/com/github/wonsim02/infra/jpa/CustomPostgresqlContainer.kt
@@ -1,0 +1,59 @@
+package com.github.wonsim02.infra.jpa
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+class CustomPostgresqlContainer(
+    dockerImageName: DockerImageName,
+    database: String,
+    username: String,
+    password: String,
+) : PostgreSQLContainer<CustomPostgresqlContainer>(dockerImageName) {
+
+    init {
+        this.withDatabaseName(database)
+            .withUsername(username)
+            .withPassword(password)
+            .withExposedPorts(5432)
+    }
+
+    constructor(
+        database: String,
+        username: String,
+        password: String,
+    ) : this(
+        dockerImageName = DockerImageName
+            .parse("public.ecr.aws/docker/library/postgres:11.14")
+            .asCompatibleSubstituteFor("postgres"),
+        database = database,
+        username = username,
+        password = password,
+    )
+
+    fun getMappedPortFor5432(): Int {
+        return this.getMappedPort(5432)
+    }
+
+    private val springPropertyGetterMap: Map<String, () -> Any> = mapOf(
+        "CONF_RDB_HOST" to this::getHost,
+        "CONF_RDB_PORT" to this::getMappedPortFor5432,
+        "CONF_RDB_DATABASE" to this::getDatabaseName,
+        "CONF_RDB_USERNAME" to this::getUsername,
+        "CONF_RDB_PASSWORD" to this::getPassword,
+    )
+
+    fun provideTestContainerProperties(): Array<String> {
+        return springPropertyGetterMap
+            .map { (propertyKey, propertyValueGetter) ->
+                "--$propertyKey=${propertyValueGetter()}"
+            }
+            .toTypedArray()
+    }
+
+    fun setTestContainerProperties(registry: DynamicPropertyRegistry) {
+        for ((propertyKey, propertyValueGetter) in springPropertyGetterMap) {
+            registry.add(propertyKey, propertyValueGetter)
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "spring-kotlin-exercise"
 
 include(":common")
+include(":examples:examples-jpa-polymorphism")
 include(":infra-jpa")
 include(":infra-mongodb")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 rootProject.name = "spring-kotlin-exercise"
 
 include(":common")
+include(":infra-jpa")
 include(":infra-mongodb")


### PR DESCRIPTION
테이블 스키마를 변경하지 않고 엔티티 재정의를 통하여 리포지토리 구현을 간결화한 예시입니다.
실제로 서비스 코드 리팩토링을 진행할 때에는 `type` 열을 판별자로 사용하기보다는 판별자로 사용할 열을 추가한 후 이미 추가된 행에 대하여 판별자 값을 채워주는 작업을 선행했습니다.