### PR TITLE
Actuator를 통한 health 검사 시 Runner 동작 완료 여부도 검사

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyHandlerScopeExtensions.kt
+++ b/buildSrc/src/main/kotlin/DependencyHandlerScopeExtensions.kt
@@ -5,6 +5,16 @@ fun DependencyHandlerScope.flyway(
     version: String = Ver.flyway,
 ): String = "org.flywaydb:flyway-$module:$version"
 
+fun DependencyHandlerScope.kotlinxSerialization(
+    module: String,
+    version: String = Ver.kotlinxSerialization,
+) = "org.jetbrains.kotlinx:kotlinx-serialization-$module:$version"
+
+fun DependencyHandlerScope.okhttp(
+    module: String,
+    version: String = Ver.okhttp,
+): String = "com.squareup.okhttp3:$module:$version"
+
 fun DependencyHandlerScope.postgres(
     version: String = Ver.postgres,
 ): String = "org.postgresql:postgresql:$version"

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -3,6 +3,7 @@ object Plugins {
     const val idea = "idea"
     const val javaTestFixtures = "java-test-fixtures"
     const val kotlin = "kotlin"
+    const val kotlinSerialization = "org.jetbrains.kotlin.plugin.serialization"
     const val kotlinJpa = "org.jetbrains.kotlin.plugin.jpa"
     const val kotlinKapt = "org.jetbrains.kotlin.kapt"
     const val kotlinSpring = "org.jetbrains.kotlin.plugin.spring"

--- a/buildSrc/src/main/kotlin/Ver.kt
+++ b/buildSrc/src/main/kotlin/Ver.kt
@@ -1,9 +1,11 @@
 object Ver {
 
-    const val flyway: String = "8.5.12"
+    const val flyway = "8.5.12"
     const val kotlin = "1.6.21"
+    const val kotlinxSerialization = "1.3.3"
     const val ktlint = "0.45.2"
     const val ktlintPlugin = "10.2.1"
+    const val okhttp = "4.9.3"
     const val postgres = "42.3.8"
     const val springBoot = "2.7.7"
     const val springDependencyManagement = "1.1.4"

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,14 @@
+plugins {
+    id(Plugins.kotlinSerialization) version Ver.kotlin
+}
+
 dependencies {
     implementation(spring("context"))
     implementation(springBoot("actuator"))
 
+    testImplementation(kotlinxSerialization("json"))
+    testImplementation(okhttp("okhttp"))
     testImplementation(springBoot("starter-test"))
     testImplementation(springBoot("starter-actuator"))
+    testImplementation(springBoot("starter-web"))
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,7 @@
 dependencies {
     implementation(spring("context"))
+    implementation(springBoot("actuator"))
 
     testImplementation(springBoot("starter-test"))
+    testImplementation(springBoot("starter-actuator"))
 }

--- a/common/src/main/kotlin/com/github/womsim02/common/spring/UseSpringBootRunnerHealthIndicator.kt
+++ b/common/src/main/kotlin/com/github/womsim02/common/spring/UseSpringBootRunnerHealthIndicator.kt
@@ -1,0 +1,13 @@
+package com.github.womsim02.common.spring
+
+import com.github.womsim02.common.spring.internal.SpringBootRunnerHealthIndicator
+import com.github.womsim02.common.spring.internal.SpringBootRunnerHealthIndicatorRegistrar
+import org.springframework.context.annotation.Import
+
+/**
+ * [SpringBootRunnerHealthIndicator]를 bean으로 등록하여 health 체크 시 runner 동작 완료 여부도 함께 체크하도록 한다.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Import(SpringBootRunnerHealthIndicatorRegistrar::class)
+annotation class UseSpringBootRunnerHealthIndicator

--- a/common/src/main/kotlin/com/github/womsim02/common/spring/internal/SpringBootRunnerHealthIndicator.kt
+++ b/common/src/main/kotlin/com/github/womsim02/common/spring/internal/SpringBootRunnerHealthIndicator.kt
@@ -1,0 +1,34 @@
+package com.github.womsim02.common.spring.internal
+
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.actuate.health.AbstractHealthIndicator
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+
+/**
+ * 스프링 부트 어플리케이션을 실행하는 과정에서 등록된 [ApplicationRunner] 및 [CommandLineRunner]을 모두 실행하기 전까지 actuator 엔드포인트를
+ * 통한 health 체크가 down`이 되도록 한다.
+ * 서버 배포 시 health 체크를 통해 요청 수신 여부를 결정한다면 등록된 runner가 전부 실행되기 전까지 서버가 요청을 수신하지 않도록 해 스프링 부트 실행 이후
+ * 서버 준비 작업이 [ApplicationRunner] 혹은 [CommandLineRunner]의 구현을 통해 가능해진다.
+ * @see org.springframework.boot.actuate.health.HealthEndpoint.getHealth
+ * @see org.springframework.boot.SpringApplication.run
+ * @see org.springframework.boot.SpringApplicationRunListeners.ready
+ */
+internal class SpringBootRunnerHealthIndicator : AbstractHealthIndicator(), ApplicationListener<ApplicationReadyEvent> {
+
+    private var ready: Boolean = false
+
+    override fun doHealthCheck(builder: Health.Builder?) {
+        if (ready) {
+            builder?.up()
+        } else {
+            builder?.down()
+        }
+    }
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        ready = true
+    }
+}

--- a/common/src/main/kotlin/com/github/womsim02/common/spring/internal/SpringBootRunnerHealthIndicatorRegistrar.kt
+++ b/common/src/main/kotlin/com/github/womsim02/common/spring/internal/SpringBootRunnerHealthIndicatorRegistrar.kt
@@ -1,0 +1,11 @@
+package com.github.womsim02.common.spring.internal
+
+import org.springframework.context.annotation.Bean
+
+internal class SpringBootRunnerHealthIndicatorRegistrar {
+
+    @Bean
+    fun springBootRunnerHealthIndicator(): SpringBootRunnerHealthIndicator {
+        return SpringBootRunnerHealthIndicator()
+    }
+}

--- a/common/src/test/kotlin/com/github/wonsim02/common/spring/SpringBootRunnerHealthIndicatorTest.kt
+++ b/common/src/test/kotlin/com/github/wonsim02/common/spring/SpringBootRunnerHealthIndicatorTest.kt
@@ -1,0 +1,145 @@
+package com.github.wonsim02.common.spring
+
+import com.github.womsim02.common.spring.UseSpringBootRunnerHealthIndicator
+import com.github.womsim02.common.spring.internal.SpringBootRunnerHealthIndicator
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.boot.runApplication
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Bean
+
+/**
+ * [UseSpringBootRunnerHealthIndicator]로 [SpringBootRunnerHealthIndicator]를 활성화했을 때 runner의 동작이 종료되기 전까지 health
+ * 체크 검사 결과가 `DOWN`인지, 그리고 runner가 모두 동작하면 health 체크 결과가 `UP`인지 검증하는 테스트.
+ */
+class SpringBootRunnerHealthIndicatorTest {
+
+    private val okHttpClient = OkHttpClient()
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `health check fails until runners are completed`() {
+        // given - start app
+        val appThread = Thread {
+            runApplication<App>(
+                "--management.server.port=$ACTUATOR_PORT",
+                "--spring.main.web-application-type=servlet",
+            )
+        }
+        appThread.start()
+
+        // given - wait until application is started
+        while (!TestApplicationStartedEventListener.applicationStarted) {
+            Thread.sleep(100L)
+        }
+
+        // when - send health check request
+        val healthCheckResult1 = doHealthCheck()
+
+        // then - status down
+        Assertions.assertNotNull(healthCheckResult1)
+        Assertions.assertEquals("DOWN", healthCheckResult1!!.status)
+
+        // given - complete command line runner
+        TestCommandLineRunner.isCompleted = true
+        Thread.sleep(100L)
+
+        // when - send health check request
+        val healthCheckResult2 = doHealthCheck()
+
+        // then - status UP
+        Assertions.assertNotNull(healthCheckResult2)
+        Assertions.assertEquals("UP", healthCheckResult2!!.status)
+
+        // after test - join thread
+        appThread.join()
+    }
+
+    private fun doHealthCheck(): HealthCheckResult? {
+        val request = Request.Builder()
+            .get()
+            .url("http://localhost:$ACTUATOR_PORT/actuator/health/")
+            .build()
+        val response = okHttpClient.newCall(request).execute()
+
+        return try {
+            response
+                .body
+                ?.bytes()
+                ?.let { json.decodeFromString(HealthCheckResult.serializer(), String(it)) }
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    @Serializable
+    data class HealthCheckResult(val status: String)
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @UseSpringBootRunnerHealthIndicator
+    class App {
+
+        @Bean
+        fun testCommandLineRunner(): TestCommandLineRunner {
+            return TestCommandLineRunner()
+        }
+
+        @Bean
+        fun testApplicationStartedEventListener(): TestApplicationStartedEventListener {
+            return TestApplicationStartedEventListener()
+        }
+    }
+
+    /**
+     * [isCompleted]가 `true`가 되기 전까지 종료되지 않는 [CommandLineRunner]의 구현체.
+     */
+    class TestCommandLineRunner : CommandLineRunner {
+
+        override fun run(vararg args: String?) {
+            val newThread = Thread {
+                while (!isCompleted) { Thread.sleep(100L) }
+            }
+
+            newThread.start()
+            newThread.join()
+        }
+
+        companion object {
+
+            @Volatile var isCompleted = false
+        }
+    }
+
+    /**
+     * 스프링 부트 어플리케이션이 실행되고 나서 runner를 실행하기 전에 발생하는 [ApplicationStartedEvent]에 대한 리스너.
+     * @see org.springframework.boot.SpringApplication.run
+     * @see org.springframework.boot.SpringApplicationRunListeners.started
+     */
+    class TestApplicationStartedEventListener : ApplicationListener<ApplicationStartedEvent> {
+
+        override fun onApplicationEvent(event: ApplicationStartedEvent) {
+            applicationStarted = true
+        }
+
+        companion object {
+
+            @Volatile var applicationStarted = false
+        }
+    }
+
+    companion object {
+
+        private const val ACTUATOR_PORT = 8585
+    }
+}


### PR DESCRIPTION
`AbstractHealthIndicator`의 구현체로 `ApplicationReadyEvent`를 수신해야 health 체크 결과를 UP으로 설정하는 컴포넌트를 추가합니다. 해당 `HealthIndicator` 구현체의 추가로 스프링 부트 어플리케이션이 실행되고 나서 Runner의 동작이 완료되기 전까지 health 체크 결과가 DOWN이 되어 서버가 요청을 받아들일 준비가 되지 않음을 알릴 수 있습니다.