### PR TITLE
테이블에 행 삽입 시 constraint 위배 방지 예시

### DIFF
--- a/examples/examples-use-hibernate-impl/build.gradle.kts
+++ b/examples/examples-use-hibernate-impl/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":infra-jpa"))
+    testImplementation(testFixtures(project(":infra-jpa")))
+}

--- a/examples/examples-use-hibernate-impl/src/main/java/com/github/wonsim02/examples/usehibernateimpl/util/HibernateExtensions.java
+++ b/examples/examples-use-hibernate-impl/src/main/java/com/github/wonsim02/examples/usehibernateimpl/util/HibernateExtensions.java
@@ -1,0 +1,128 @@
+package com.github.wonsim02.examples.usehibernateimpl.util;
+
+import org.hibernate.action.internal.EntityInsertAction;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.internal.AbstractSaveEventListener;
+import org.hibernate.event.internal.DefaultMergeEventListener;
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.jdbc.Expectation;
+import org.hibernate.jdbc.Expectations;
+import org.hibernate.persister.entity.AbstractEntityPersister;
+import org.hibernate.HibernateException;
+import org.hibernate.persister.entity.EntityPersister;
+import org.jetbrains.annotations.NotNull;
+
+import javax.persistence.EntityManager;
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.Function;
+import java.util.Map;
+
+/**
+ * Hibernate의 구현을 응용한 확장 함수 모음.
+ * Javadoc을 사용하기 위해 JAVA로 작성함.
+ */
+class HibernateExtensions {
+
+    /**
+     * {@link AbstractEntityPersister#insert(Serializable, Object[], boolean[], int, String, Object, SharedSessionContractImplementor) insert}
+     * 함수에서 배치 쿼리 실행 여부가 {@code false}일 때의 로직을 실행한다.
+     */
+    static int performEarlyInsert(
+        @NotNull AbstractEntityPersister persister,
+        @NotNull Serializable id,
+        @NotNull Object[] fields,
+        @NotNull boolean[] notNull,
+        int idx,
+        @NotNull String sql,
+        @NotNull SessionImpl session
+    ) throws SQLException, HibernateException {
+        @NotNull Expectation expectation = Expectations.appropriateExpectation(
+            persister.getInsertResultCheckStyles()[idx]
+        );
+        boolean callable = persister.isInsertCallable(idx);
+
+        @NotNull PreparedStatement insert = session
+            .getJdbcCoordinator()
+            .getStatementPreparer()
+            .prepareStatement(sql, callable);
+
+        persister.dehydrate(
+            /* id = */ id,
+            /* fields = */ fields,
+            /* rowId = */ null,
+            /* includeProperty = */ notNull,
+            /* includeColumns = */ persister.getPropertyColumnInsertable(),
+            /* j = */ idx,
+            /* ps = */ insert,
+            /* session = */ session,
+            /* index = */1 + expectation.prepare(insert),
+            /* isUpdate = */false
+        );
+
+        return session
+            .getJdbcCoordinator()
+            .getResultSetReturn()
+            .executeUpdate(insert);
+    }
+
+    /**
+     * {@link AbstractEntityPersister#insert(Serializable, Object[], Object, SharedSessionContractImplementor) insert}
+     * 함수에서 SQL 쿼리에 {@code on conflict} 구문을 추가하여 실행한다.
+     * @param entity {@code insert} 쿼리를 실행하려는 대상
+     * @param session {@link EntityManager#getDelegate()}로 얻은 {@link SessionImpl}
+     * @param persister {@param entity}에 대한 {@link AbstractEntityPersister}
+     * @param mergeMap {@link DefaultMergeEventListener#getMergeMap}로 얻은 {@link Map}
+     * @param onConflictStatement {@code on conflict} 구문으로 지정할 행동
+     * @param entityIdGetter {@param entity}의 ID를 반환하는 함수
+     * @param <T> 엔티티의 타입
+     * @param <ID> 엔티티 ID의 타입
+     * @return {@code insert} 구문으로 엔티티가 추가되었는지 여부
+     * @throws SQLException {@link HibernateExtensions#performEarlyInsert(AbstractEntityPersister, Serializable, Object[], boolean[], int, String, SessionImpl)}로부터 생성된 예외
+     * @throws HibernateException {@link HibernateExtensions#performEarlyInsert(AbstractEntityPersister, Serializable, Object[], boolean[], int, String, SessionImpl)}로부터 생성된 예외
+     * @see AbstractSaveEventListener#performSaveOrReplicate(Object, EntityKey, EntityPersister, boolean, Object, EventSource, boolean)
+     * @see EntityInsertAction
+     */
+    static <T, ID extends Serializable> boolean performConstraintViolationInsertion(
+        @NotNull T entity,
+        @NotNull SessionImpl session,
+        @NotNull AbstractEntityPersister persister,
+        @SuppressWarnings("rawtypes") @NotNull Map mergeMap,
+        @NotNull String onConflictStatement,
+        @NotNull Function<T, ID> entityIdGetter
+    ) throws SQLException, HibernateException {
+        @NotNull Object[] propertyValues = persister.getPropertyValuesToInsert(
+            /* object = */ entity,
+            /* mergeMap = */ mergeMap,
+            /* session = */ ((SharedSessionContractImplementor) session)
+        );
+        boolean[] propertyInsertability = persister.getPropertyInsertability();
+        String[] sqlInsertStrings = persister.getSQLInsertStrings();
+
+        boolean insertSuccessful = true;
+        for (int idx = 0; idx < sqlInsertStrings.length; idx++) {
+            @NotNull String sql = sqlInsertStrings[idx];
+            @NotNull String newSql = sql + " on conflict " + onConflictStatement;
+            @NotNull ID id = entityIdGetter.apply(entity);
+
+            int insertedCount = performEarlyInsert(
+                /* persister = */ persister,
+                /* id = */ id,
+                /* fields = */ propertyValues,
+                /* notNull = */ propertyInsertability,
+                /* idx = */ idx,
+                /* sql = */ newSql,
+                /* session = */ session
+            );
+
+            if (insertedCount != 1) {
+                insertSuccessful = false;
+            }
+        }
+
+        return insertSuccessful;
+    }
+}

--- a/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/config/ExamplesUseHibernateImplConfiguration.kt
+++ b/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/config/ExamplesUseHibernateImplConfiguration.kt
@@ -1,0 +1,10 @@
+package com.github.wonsim02.examples.usehibernateimpl.config
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@Configuration
+@EntityScan(basePackages = ["com.github.wonsim02.examples.usehibernateimpl.entity"])
+@EnableJpaRepositories(basePackages = ["com.github.wonsim02.examples.usehibernateimpl.entity"])
+class ExamplesUseHibernateImplConfiguration

--- a/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/entity/SampleEntity.kt
+++ b/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/entity/SampleEntity.kt
@@ -1,0 +1,36 @@
+package com.github.wonsim02.examples.usehibernateimpl.entity
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+import javax.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    schema = "public",
+    name = "sample_entity",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "unique_property__uniq",
+            columnNames = [SampleEntity.UNIQUE_PROPERTY],
+        ),
+    ],
+)
+class SampleEntity(
+    @Id
+    val id: Long,
+
+    @Column(name = UNIQUE_PROPERTY)
+    val uniqueProperty: String,
+
+    @Column(name = NON_UNIQUE_PROPERTY)
+    val nonUniqueProperty: Int,
+) {
+
+    companion object {
+
+        const val UNIQUE_PROPERTY = "unique_property"
+        const val NON_UNIQUE_PROPERTY = "non_unique_property"
+    }
+}

--- a/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/entity/SampleEntityJpaRepository.kt
+++ b/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/entity/SampleEntityJpaRepository.kt
@@ -1,0 +1,5 @@
+package com.github.wonsim02.examples.usehibernateimpl.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SampleEntityJpaRepository : JpaRepository<SampleEntity, Long>

--- a/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/util/HibernateExtensions.kt
+++ b/examples/examples-use-hibernate-impl/src/main/kotlin/com/github/wonsim02/examples/usehibernateimpl/util/HibernateExtensions.kt
@@ -1,0 +1,58 @@
+package com.github.wonsim02.examples.usehibernateimpl.util
+
+import org.hibernate.event.internal.AbstractSaveEventListener
+import org.hibernate.event.internal.DefaultMergeEventListener
+import org.hibernate.event.internal.MergeContext
+import org.hibernate.event.spi.EntityCopyObserverFactory
+import org.hibernate.internal.SessionImpl
+import org.hibernate.persister.entity.AbstractEntityPersister
+import java.io.Serializable
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+/**
+ * [DefaultMergeEventListener.onMerge] 함수 내 로직에서 [AbstractEntityPersister.getPropertyValuesToInsert]의 안자로 사용할
+ * [Map]을 구하는 과정을 재현한 함수.
+ * @see DefaultMergeEventListener.onMerge
+ * @see DefaultMergeEventListener.createEntityCopyObserver
+ * @see DefaultMergeEventListener.getMergeMap
+ * @see AbstractSaveEventListener.performSave
+ * @see AbstractSaveEventListener.performSaveOrReplicate
+ */
+internal fun getMergeMap(session: SessionImpl): Map<*, *> {
+    val serviceRegistry = session.factory.serviceRegistry
+    val entityCopyObserver = serviceRegistry
+        .getService(EntityCopyObserverFactory::class.java)
+        .createEntityCopyObserver()
+
+    return MergeContext(session, entityCopyObserver).invertMap()
+}
+
+/**
+ * constraint violation을 발생시키지 않고 엔티티 `insert`를 수행할 수 있게 한다.
+ * @param entity `insert`하려는 엔티티
+ * @param entityManager [PersistenceContext] 어노테이션을 통해 주입받은 [EntityManager]
+ * @param onConflictStatement `on conflict` 구문으로 지정할 행동
+ * @param entityIdGetter [entity]의 ID를 반환하는 함수
+ * @return [Boolean] 엔티티 `insert` 성공 여부
+ */
+internal fun <T : Any, ID : Serializable> performConstraintViolationSafeInsertion(
+    entity: T,
+    entityManager: EntityManager,
+    onConflictStatement: String = "do nothing",
+    entityIdGetter: (T) -> ID,
+): Boolean {
+    val session = entityManager.delegate as? SessionImpl ?: return false
+    val persister = session
+        .getEntityPersister(null, entity) as? AbstractEntityPersister
+        ?: return false
+
+    return HibernateExtensions.performConstraintViolationInsertion(
+        /* entity = */ entity,
+        /* session = */ session,
+        /* persister = */ persister,
+        /* mergeMap = */ getMergeMap(session),
+        /* onConflictStatement = */ onConflictStatement,
+        /* entityIdGetter = */ entityIdGetter,
+    )
+}

--- a/examples/examples-use-hibernate-impl/src/test/kotlin/com/github/wonsim02/examples/usehibernateimpl/HibernateExtensionsTest.kt
+++ b/examples/examples-use-hibernate-impl/src/test/kotlin/com/github/wonsim02/examples/usehibernateimpl/HibernateExtensionsTest.kt
@@ -1,0 +1,171 @@
+package com.github.wonsim02.examples.usehibernateimpl
+
+import com.github.wonsim02.examples.usehibernateimpl.config.ExamplesUseHibernateImplConfiguration
+import com.github.wonsim02.examples.usehibernateimpl.entity.SampleEntity
+import com.github.wonsim02.examples.usehibernateimpl.entity.SampleEntity.Companion.NON_UNIQUE_PROPERTY
+import com.github.wonsim02.examples.usehibernateimpl.entity.SampleEntity.Companion.UNIQUE_PROPERTY
+import com.github.wonsim02.examples.usehibernateimpl.entity.SampleEntityJpaRepository
+import com.github.wonsim02.examples.usehibernateimpl.util.performConstraintViolationSafeInsertion
+import com.github.wonsim02.infra.jpa.CustomPostgresqlContainer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.junit.jupiter.Container
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@SpringBootTest(classes = [HibernateExtensionsTest.App::class])
+class HibernateExtensionsTest {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Autowired
+    private lateinit var sampleEntityJpaRepository: SampleEntityJpaRepository
+
+    @Test
+    @Transactional
+    fun `performConstraintViolationSafeInsertion() works as expected`() {
+        // given - insert one entity
+        sampleEntityJpaRepository.saveAndFlush(
+            SampleEntity(
+                id = 1L,
+                uniqueProperty = "foo",
+                nonUniqueProperty = 1,
+            )
+        )
+
+        // when - insert another entity with performConstraintViolationSafeInsertion()
+        val inserted1 = performConstraintViolationSafeInsertion(
+            entity = SampleEntity(
+                id = 2L,
+                uniqueProperty = "bar",
+                nonUniqueProperty = 2,
+            ),
+            entityManager = entityManager,
+            entityIdGetter = SampleEntity::id,
+        )
+
+        // then - inserted
+        assertTrue(inserted1)
+
+        // when - findAll()
+        val allEntities1 = sampleEntityJpaRepository
+            .findAll()
+            .sortedBy { it.id }
+
+        // then - verify findAll() result
+        // two entities found (one inserted by save(), another inserted by performConstraintViolationSafeInsertion())
+        assertEquals(2, allEntities1.size)
+        with(allEntities1[0]) {
+            assertEquals(1L, id)
+            assertEquals("foo", uniqueProperty)
+            assertEquals(1, nonUniqueProperty)
+        }
+        with(allEntities1[1]) {
+            assertEquals(2L, id)
+            assertEquals("bar", uniqueProperty)
+            assertEquals(2, nonUniqueProperty)
+        }
+
+        // when - insert entity with already-existing uniqueProperty value
+        val inserted2 = performConstraintViolationSafeInsertion(
+            entity = SampleEntity(
+                id = 3L,
+                uniqueProperty = "foo",
+                nonUniqueProperty = 3,
+            ),
+            entityManager = entityManager,
+            entityIdGetter = SampleEntity::id,
+        )
+
+        // then - not inserted
+        assertFalse(inserted2)
+
+        // when - findAll()
+        val allEntities2 = sampleEntityJpaRepository
+            .findAll()
+            .onEach(entityManager::refresh)
+            .sortedBy { it.id }
+
+        // then - verify findAll() result
+        // no entities inserted or updated
+        assertEquals(2, allEntities2.size)
+        with(allEntities2[0]) {
+            assertEquals(1L, id)
+            assertEquals("foo", uniqueProperty)
+            assertEquals(1, nonUniqueProperty)
+        }
+        with(allEntities2[1]) {
+            assertEquals(2L, id)
+            assertEquals("bar", uniqueProperty)
+            assertEquals(2, nonUniqueProperty)
+        }
+
+        // when - insert entity with on conflict update clause
+        val inserted3 = performConstraintViolationSafeInsertion(
+            entity = SampleEntity(
+                id = 4L,
+                uniqueProperty = "bar",
+                nonUniqueProperty = 4,
+            ),
+            entityManager = entityManager,
+            onConflictStatement = "($UNIQUE_PROPERTY) do update set $NON_UNIQUE_PROPERTY = excluded.$NON_UNIQUE_PROPERTY",
+            entityIdGetter = SampleEntity::id,
+        )
+
+        // then - inserted (actually upserted)
+        assertTrue(inserted3)
+
+        // when - findAll()
+        val allEntities3 = sampleEntityJpaRepository
+            .findAll()
+            .onEach(entityManager::refresh)
+            .sortedBy { it.id }
+
+        // then - verify findAll() result
+        // number of entities not increased, but entity with id=2L updated
+        assertEquals(2, allEntities3.size)
+        with(allEntities3[0]) {
+            assertEquals(1L, id)
+            assertEquals("foo", uniqueProperty)
+            assertEquals(1, nonUniqueProperty)
+        }
+        with(allEntities3[1]) {
+            assertEquals(2L, id)
+            assertEquals("bar", uniqueProperty)
+            assertEquals(4, nonUniqueProperty)
+        }
+    }
+
+    @SpringBootApplication
+    @Import(ExamplesUseHibernateImplConfiguration::class)
+    class App
+
+    companion object {
+
+        @Container
+        @JvmStatic
+        val testContainer = CustomPostgresqlContainer(
+            database = "database",
+            username = "username",
+            password = "password",
+        )
+
+        @DynamicPropertySource
+        @JvmStatic
+        @Suppress("unused")
+        fun setTestDatabaseProperties(registry: DynamicPropertyRegistry) {
+            testContainer.start()
+            testContainer.setTestContainerProperties(registry)
+        }
+    }
+}

--- a/examples/examples-use-hibernate-impl/src/test/resources/application.yml
+++ b/examples/examples-use-hibernate-impl/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  flyway:
+    schemas: public
+  jpa:
+    show-sql: true

--- a/examples/examples-use-hibernate-impl/src/test/resources/db/migration/V0.0.0__init.sql
+++ b/examples/examples-use-hibernate-impl/src/test/resources/db/migration/V0.0.0__init.sql
@@ -1,0 +1,8 @@
+create schema if not exists public;
+
+create table if not exists public.sample_entity(
+    id                  bigint not null primary key,
+    unique_property     text not null,
+    non_unique_property int not null,
+    constraint unique_property__uniq unique (unique_property)
+);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,5 +2,6 @@ rootProject.name = "spring-kotlin-exercise"
 
 include(":common")
 include(":examples:examples-jpa-polymorphism")
+include(":examples:examples-use-hibernate-impl")
 include(":infra-jpa")
 include(":infra-mongodb")


### PR DESCRIPTION
`EntityManager.merge()`의 행 삽입 로직을 참고, `insert` 쿼리에 Postgres에서 지원하는 `on conflict` 구문을 설정할 수 있게 하여 constraint 위배 상황에 아무런 행동도 하지 않거나 이미 존재하는 행의 값을 수정할 수 있게 합니다.

(`EntityManager.persist()` 대신 `EntityManager.merge()`를 택한 이유는 엔티티의 ID 속성에 `@GeneratedValue` 설정이 추가된 경우 `persist()` 함수가 ID를 자체적으로 재배정하기 때문입니다.)

해당 구현이 JPA 구현 라이브러리 혹은 실제 사용하는 DB의 영향을 받기 때문에 일반적으로 좋은 접근법은 아니지만, 2개 이상 테이블의 값을 동기화시키는 등의 상황에서 분기 로직 및 fallback 로직을 간소화할 수 있기 때문에, 코드 레벨의 데이터 마이그레이션 같은 임시로 사용되는 코드에 적극적으로 사용했습니다.

see: https://www.postgresql.org/docs/current/sql-insert.html