### PR TITLE
Redis `mget` 및 `hget`/`hset` 명령어를 이용한 성능 최적화 예시 소개

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Mac ###
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Kotlin Spring을 이용하여 개발하면서 추가한 확장 기능 혹은 특
 - `:common` [README.md](common/README.md)
 - `:examples`
   - `:examples-jpa-polymorphism` [README.md](examples/examples-jpa-polymorphism/README.md)
+  - `:examples-redis-cache-using-hash` [README.md](examples/examples-redis-cache-using-hash/README.md)
   - `:examples-share-row-id-sequence` [README.md](examples/examples-share-row-id-sequence/README.md)
   - `:examples-use-hibernate-impl` [README.md](examples/examples-use-hibernate-impl/README.md)
 - `:infra-jpa` [README.md](infra-jpa/README.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 plugins {
     idea
     `java-test-fixtures`
+    kotlin("plugin.allopen") version Ver.kotlin
     kotlin("jvm") version Ver.kotlin
     kotlin("kapt") version Ver.kotlin
 

--- a/buildSrc/src/main/kotlin/DependencyHandlerScopeExtensions.kt
+++ b/buildSrc/src/main/kotlin/DependencyHandlerScopeExtensions.kt
@@ -32,6 +32,11 @@ fun DependencyHandlerScope.queryDsl(
     version: String = Ver.queryDsl,
 ) = "com.querydsl:$module:$version"
 
+fun DependencyHandlerScope.retrofit(
+    module: String,
+    version: String = Ver.retrofit,
+): String = "com.squareup.retrofit2:$module:$version"
+
 fun DependencyHandlerScope.spring(
     module: String,
 ): String = "org.springframework:spring-$module"

--- a/buildSrc/src/main/kotlin/Ver.kt
+++ b/buildSrc/src/main/kotlin/Ver.kt
@@ -9,6 +9,7 @@ object Ver {
     const val okhttp = "4.9.3"
     const val postgres = "42.3.8"
     const val queryDsl = "5.0.0"
+    const val retrofit = "2.9.0"
     const val springBoot = "2.7.7"
     const val springDependencyManagement = "1.1.4"
     const val testContainers = "1.19.4"

--- a/common/src/main/kotlin/com/github/womsim02/common/util/ApplyUtils.kt
+++ b/common/src/main/kotlin/com/github/womsim02/common/util/ApplyUtils.kt
@@ -1,0 +1,9 @@
+package com.github.womsim02.common.util
+
+inline fun <T, V : Any> T.applyIfNotNull(
+    value: V?,
+    applyBlock: T.(V) -> Unit,
+): T {
+    if (value != null) { applyBlock(value) }
+    return this
+}

--- a/examples/examples-redis-cache-using-hash/API_SPEC.md
+++ b/examples/examples-redis-cache-using-hash/API_SPEC.md
@@ -1,0 +1,73 @@
+# API Spec
+
+## 모델 목록
+
+### User
+
+서비스 사용자
+
+| property  | type      | description                       |
+|-----------|-----------|-----------------------------------|
+| `id`      | int64     | 사용자 고유 ID. API 인증에 사용된다.     |
+| `name`    | string    | 사용자 이름.                         |
+
+### Video
+
+시청 가능한 영상
+
+| property  | type      | description       |
+|-----------|-----------|-------------------|
+| `id`      | int64     | 영상 고유 ID.        |
+| `title`   | string    | 영상 제목.           |
+
+### PlayListWithDetails
+
+여러 영상을 취합한 재생 목록
+
+| property              | type      | description                                   |
+|-----------------------|-----------|-----------------------------------------------|
+| `id`                  | int64     | 재생 목록 고유 ID                                 |
+| `title`               | string    | 재생 목록 제목.                                   |
+| `videos`              | array     | 재생 목록에 속한 영상 목록                          |
+| `watchedVideosCount`  | int32     | 재생 목록에 속한 영상 중 한 번이라도 시청한 영상의 개수    |
+
+### WatchHistory
+
+사용자의 영상 시청 기록
+
+| property      | type      | description               |
+|---------------|-----------|---------------------------|
+| `id`          | int64     | 시청 기록 고유 ID             |
+| `user_id`     | int64     | 사용자 ID                   |
+| `video_id`    | int64     | 영상 ID                     |
+
+### 
+
+## API 목록
+
+공통적으로 인증은 `x-user-id` 헤더에 사용자 ID를 설정하는 방식으로 진행된다. (see: `UserIdHeaderParameterConfiguration`)
+
+### GET `/playlists`
+
+- 요청
+
+  | name      | type          | required  | description           |
+  |-----------|---------------|-----------|-----------------------|
+  | `cursor`  | request param | false     | 재생 목록 ID에 대한 커서.  |
+  | `limit`   | request param | true      | 조회할 재생 목록 최대 개수. |
+
+- 응답 : `ListPlayListsResponse`
+
+  | property      | type      | description                   |
+  |---------------|-----------|-------------------------------|
+  | `playLists`   | array     | `PlayListWithDetails` 목록     |
+
+### PUT `/watch-histories`
+
+- 요청
+
+  | name          | type          | required  | description     |
+  |---------------|---------------|-----------|-----------------|
+  | `video_id`    | request param | true      | 시청한 영상의 ID    |
+
+- 응답 : `WatchHistory`

--- a/examples/examples-redis-cache-using-hash/README.md
+++ b/examples/examples-redis-cache-using-hash/README.md
@@ -1,0 +1,86 @@
+# `examples-redis-cache-using-hash`
+
+Redis 캐시 및 Redis 자체 연산을 이용한 API 응답 시간 최적화 예시 소개용 모듈. ([API Spec](API_SPEC.md))
+
+Also see: [Redis mget 및 hget/hset 명령어를 이용한 성능 최적화 예시 소개 #15](https://github.com/wonsim02/spring-kotlin-exercise/pull/15)
+
+## `mget` 명령어를 이용한 응답 시간 최적화 (`VideoCache`)
+
+```kotlin
+fun multiGet(videoIds: Collection<Long>): Map<Long, Video> {
+    if (videoIds.isEmpty()) return mapOf()
+
+    val cacheKeys = videoIds.map { "$prefix$it" }
+    return redisTemplate
+        .opsForValue()
+        .multiGet(cacheKeys)
+        ?.asSequence()
+        ?.mapNotNull { redisValueSerializer.deserialize(it) as? Video }
+        ?.associateBy { it.id }
+        ?: mapOf()
+}
+```
+
+## `hget` 및 `hset` 명렁어를 이용한 응답 시간 최적화 (`WatchHistoryCountsCache`)
+
+```kotlin
+fun get(videoIds: Collection<Long>): WatchHistoryCounts {
+    if (videoIds.isEmpty()) return mapOf()
+
+    return redisTemplate
+        .opsForHash<Long, WatchHistoryCountsEntry>()
+        .multiGet(cacheKey, videoIds)
+        .asSequence()
+        .filterNotNull()
+        .associate { it.videoId to it.count }
+}
+
+fun put(watchHistoryCounts: WatchHistoryCounts) {
+    if (watchHistoryCounts.isEmpty()) return
+    val entries = watchHistoryCounts.mapValues { (videoId, count) ->
+        WatchHistoryCountsEntry(videoId = videoId, count = count)
+    }
+
+    redisTemplate
+        .opsForHash<Long, WatchHistoryCountsEntry>()
+        .putAll(cacheKey, entries)
+    redisTemplate.expire(cacheKey, cacheDuration)
+}
+```
+
+## 테스트 실행 방법
+
+`WatchingHistoryCountsCacheConfigurationTest`의 서브클래스로 `WatchHistoryCountsCache` 빈이
+등록되어 있을 때와 없을 때 2가지 경우에 대한 테스트 클래스가 작성되어 있다:
+
+- `WatchHistoryCountsCache` 빈 등록됨 :
+  - class : `Enabled`
+  - gradle task : `:watchingHistoryCountsCacheEnabledTest`
+- `WatchHistoryCountsCache` 빈이 등록되지 않음 :
+  - class : `Disabled`
+  - gradle task : `:watchingHistoryCountsCacheDisabledTest`
+
+실행할 테스트를 선택한 다음 다음 명령어로 테스트 실행이 가능하다:
+
+
+### Windows
+
+```shell
+./gradlew.bat :examples:examples-redis-cache-using-hash:${gradle_task}
+```
+
+### Linux / Mac
+
+```shell
+./gradlew :examples:examples-redis-cache-using-hash:${gradle_task}
+```
+
+## 테스트 실행 결과 (평균 API 응답 시간)
+
+- [Enabled Test Log](logs/enabled.log)
+- [Disabled Test Log](logs/disabled.log)
+
+| `WatchHistoryCountsCache` enabled | GET `/playlists` | PUT `/watch-histories` |
+|-----------------------------------|------------------|------------------------|
+| true                              | 25.61 ms         | 79.47 ms               |
+| false                             | 36.22 ms         | 67.19 ms               |

--- a/examples/examples-redis-cache-using-hash/README.md
+++ b/examples/examples-redis-cache-using-hash/README.md
@@ -21,28 +21,28 @@ fun multiGet(videoIds: Collection<Long>): Map<Long, Video> {
 }
 ```
 
-## `hget` 및 `hset` 명렁어를 이용한 응답 시간 최적화 (`WatchHistoryCountsCache`)
+## `hget` 및 `hset` 명렁어를 이용한 응답 시간 최적화 (`WatchedVideosCountsCache`)
 
 ```kotlin
-fun get(videoIds: Collection<Long>): WatchHistoryCounts {
-    if (videoIds.isEmpty()) return mapOf()
+fun get(playListIds: Collection<Long>): WatchedVideosCounts {
+    if (playListIds.isEmpty()) return mapOf()
 
     return redisTemplate
-        .opsForHash<Long, WatchHistoryCountsEntry>()
-        .multiGet(cacheKey, videoIds)
+        .opsForHash<Long, WatchedVideosCountsEntry>()
+        .multiGet(cacheKey, playListIds)
         .asSequence()
         .filterNotNull()
-        .associate { it.videoId to it.count }
+        .associate { it.playListId to it.count }
 }
 
-fun put(watchHistoryCounts: WatchHistoryCounts) {
+fun put(watchHistoryCounts: WatchedVideosCounts) {
     if (watchHistoryCounts.isEmpty()) return
-    val entries = watchHistoryCounts.mapValues { (videoId, count) ->
-        WatchHistoryCountsEntry(videoId = videoId, count = count)
+    val entries = watchHistoryCounts.mapValues { (playListId, count) ->
+        WatchedVideosCountsEntry(playListId = playListId, count = count)
     }
 
     redisTemplate
-        .opsForHash<Long, WatchHistoryCountsEntry>()
+        .opsForHash<Long, WatchedVideosCountsEntry>()
         .putAll(cacheKey, entries)
     redisTemplate.expire(cacheKey, cacheDuration)
 }
@@ -50,15 +50,15 @@ fun put(watchHistoryCounts: WatchHistoryCounts) {
 
 ## 테스트 실행 방법
 
-`WatchingHistoryCountsCacheConfigurationTest`의 서브클래스로 `WatchHistoryCountsCache` 빈이
+`WatchedVideosCountsCacheConfigurationTest`의 서브클래스로 `WatchedVideosCountsCache` 빈이
 등록되어 있을 때와 없을 때 2가지 경우에 대한 테스트 클래스가 작성되어 있다:
 
 - `WatchHistoryCountsCache` 빈 등록됨 :
   - class : `Enabled`
-  - gradle task : `:watchingHistoryCountsCacheEnabledTest`
+  - gradle task : `:watchedVideosCountsCacheEnabledTest`
 - `WatchHistoryCountsCache` 빈이 등록되지 않음 :
   - class : `Disabled`
-  - gradle task : `:watchingHistoryCountsCacheDisabledTest`
+  - gradle task : `:watchedVideosCountsCacheDisabledTest`
 
 실행할 테스트를 선택한 다음 다음 명령어로 테스트 실행이 가능하다:
 
@@ -80,7 +80,7 @@ fun put(watchHistoryCounts: WatchHistoryCounts) {
 - [Enabled Test Log](logs/enabled.log)
 - [Disabled Test Log](logs/disabled.log)
 
-| `WatchHistoryCountsCache` enabled | GET `/playlists` | PUT `/watch-histories` |
-|-----------------------------------|------------------|------------------------|
-| true                              | 25.61 ms         | 79.47 ms               |
-| false                             | 36.22 ms         | 67.19 ms               |
+| `WatchedVideosCountsCache` enabled  | GET `/playlists`  | PUT `/watch-histories`  |
+|-------------------------------------|-------------------|-------------------------|
+| true                                | 16.854 ms         | 10.024 ms               |
+| false                               | 43.430 ms         | 7.108 ms                |

--- a/examples/examples-redis-cache-using-hash/build.gradle.kts
+++ b/examples/examples-redis-cache-using-hash/build.gradle.kts
@@ -1,0 +1,20 @@
+allOpen {
+    annotation("javax.persistence.Entity")
+}
+
+dependencies {
+    implementation(springBoot("starter-web"))
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.springdoc:springdoc-openapi-ui:1.7.0")
+
+    implementation(project(":common"))
+    implementation(project(":infra-jpa"))
+    implementation(project(":infra-redis"))
+
+    implementation(queryDsl("querydsl-core"))
+    implementation(queryDsl("querydsl-jpa"))
+    kapt(queryDsl("querydsl-apt", version = "${Ver.queryDsl}:jpa"))
+
+    testImplementation(testFixtures(project(":infra-jpa")))
+    testImplementation(testFixtures(project(":infra-redis")))
+}

--- a/examples/examples-redis-cache-using-hash/build.gradle.kts
+++ b/examples/examples-redis-cache-using-hash/build.gradle.kts
@@ -22,16 +22,16 @@ dependencies {
 }
 
 tasks {
-    val testBaseClass = "com.github.wonsim02.examples.rediscacheusinghash.WatchingHistoryCountsCacheConfigurationTest"
+    val testBaseClass = "com.github.wonsim02.examples.rediscacheusinghash.WatchedVideosCountsCacheConfigurationTest"
 
-    register<Test>("watchingHistoryCountsCacheEnabledTest") {
+    register<Test>("watchedVideosCountsCacheEnabledTest") {
         group = "verification"
         filter {
             includeTest("$testBaseClass\$Enabled", null)
         }
     }
 
-    register<Test>("watchingHistoryCountsCacheDisabledTest") {
+    register<Test>("watchedVideosCountsCacheDisabledTest") {
         group = "verification"
         filter {
             includeTest("$testBaseClass\$Disabled", null)

--- a/examples/examples-redis-cache-using-hash/build.gradle.kts
+++ b/examples/examples-redis-cache-using-hash/build.gradle.kts
@@ -20,3 +20,21 @@ dependencies {
     testImplementation(testFixtures(project(":infra-jpa")))
     testImplementation(testFixtures(project(":infra-redis")))
 }
+
+tasks {
+    val testBaseClass = "com.github.wonsim02.examples.rediscacheusinghash.WatchingHistoryCountsCacheConfigurationTest"
+
+    register<Test>("watchingHistoryCountsCacheEnabledTest") {
+        group = "verification"
+        filter {
+            includeTest("$testBaseClass\$Enabled", null)
+        }
+    }
+
+    register<Test>("watchingHistoryCountsCacheDisabledTest") {
+        group = "verification"
+        filter {
+            includeTest("$testBaseClass\$Disabled", null)
+        }
+    }
+}

--- a/examples/examples-redis-cache-using-hash/build.gradle.kts
+++ b/examples/examples-redis-cache-using-hash/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation(queryDsl("querydsl-jpa"))
     kapt(queryDsl("querydsl-apt", version = "${Ver.queryDsl}:jpa"))
 
+    testImplementation(retrofit("retrofit"))
+    testImplementation(retrofit("converter-jackson"))
     testImplementation(testFixtures(project(":infra-jpa")))
     testImplementation(testFixtures(project(":infra-redis")))
 }

--- a/examples/examples-redis-cache-using-hash/logs/disabled.log
+++ b/examples/examples-redis-cache-using-hash/logs/disabled.log
@@ -1,0 +1,3 @@
+2024-05-06 19:50:28.528  INFO 87819 --- [    Test worker] oryCountsCacheConfigurationTest$Disabled : Total elapsed time is 694997 ms.
+2024-05-06 19:50:28.528  INFO 87819 --- [    Test worker] oryCountsCacheConfigurationTest$Disabled : Total elapsed time of createWatchHistory is 6719 ms.
+2024-05-06 19:50:28.528  INFO 87819 --- [    Test worker] oryCountsCacheConfigurationTest$Disabled : Total elapsed time of listPlyLists is 688267 ms.

--- a/examples/examples-redis-cache-using-hash/logs/disabled.log
+++ b/examples/examples-redis-cache-using-hash/logs/disabled.log
@@ -1,3 +1,3 @@
-2024-05-06 19:50:28.528  INFO 87819 --- [    Test worker] oryCountsCacheConfigurationTest$Disabled : Total elapsed time is 694997 ms.
-2024-05-06 19:50:28.528  INFO 87819 --- [    Test worker] oryCountsCacheConfigurationTest$Disabled : Total elapsed time of createWatchHistory is 6719 ms.
-2024-05-06 19:50:28.528  INFO 87819 --- [    Test worker] oryCountsCacheConfigurationTest$Disabled : Total elapsed time of listPlyLists is 688267 ms.
+2024-05-10 08:59:47.177  INFO 18430 --- [    Test worker] eosCountsCacheConfigurationTest$Disabled : Total elapsed time is 832301 ms.
+2024-05-10 08:59:47.177  INFO 18430 --- [    Test worker] eosCountsCacheConfigurationTest$Disabled : Total elapsed time of createWatchHistory is 7108 ms.
+2024-05-10 08:59:47.177  INFO 18430 --- [    Test worker] eosCountsCacheConfigurationTest$Disabled : Total elapsed time of listPlyLists is 825172 ms.

--- a/examples/examples-redis-cache-using-hash/logs/enabled.log
+++ b/examples/examples-redis-cache-using-hash/logs/enabled.log
@@ -1,0 +1,3 @@
+2024-05-06 20:07:42.742  INFO 87895 --- [    Test worker] toryCountsCacheConfigurationTest$Enabled : Total elapsed time is 494631 ms.
+2024-05-06 20:07:42.743  INFO 87895 --- [    Test worker] toryCountsCacheConfigurationTest$Enabled : Total elapsed time of createWatchHistory is 7947 ms.
+2024-05-06 20:07:42.743  INFO 87895 --- [    Test worker] toryCountsCacheConfigurationTest$Enabled : Total elapsed time of listPlyLists is 486660 ms.

--- a/examples/examples-redis-cache-using-hash/logs/enabled.log
+++ b/examples/examples-redis-cache-using-hash/logs/enabled.log
@@ -1,3 +1,3 @@
-2024-05-06 20:07:42.742  INFO 87895 --- [    Test worker] toryCountsCacheConfigurationTest$Enabled : Total elapsed time is 494631 ms.
-2024-05-06 20:07:42.743  INFO 87895 --- [    Test worker] toryCountsCacheConfigurationTest$Enabled : Total elapsed time of createWatchHistory is 7947 ms.
-2024-05-06 20:07:42.743  INFO 87895 --- [    Test worker] toryCountsCacheConfigurationTest$Enabled : Total elapsed time of listPlyLists is 486660 ms.
+2024-05-10 09:28:00.236  INFO 18603 --- [    Test worker] deosCountsCacheConfigurationTest$Enabled : Total elapsed time is 330265 ms.
+2024-05-10 09:28:00.236  INFO 18603 --- [    Test worker] deosCountsCacheConfigurationTest$Enabled : Total elapsed time of createWatchHistory is 10024 ms.
+2024-05-10 09:28:00.236  INFO 18603 --- [    Test worker] deosCountsCacheConfigurationTest$Enabled : Total elapsed time of listPlyLists is 320217 ms.

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/App.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/App.kt
@@ -1,0 +1,8 @@
+package com.github.wonsim02.examples.rediscacheusinghash
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
+
+@SpringBootApplication
+@EntityScan(basePackages = ["com.github.wonsim02.examples.rediscacheusinghash"])
+class App

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/UserCache.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/UserCache.kt
@@ -1,0 +1,34 @@
+package com.github.wonsim02.examples.rediscacheusinghash.cache
+
+import com.github.wonsim02.examples.rediscacheusinghash.config.CustomRedisCacheConfiguration
+import com.github.wonsim02.examples.rediscacheusinghash.model.User
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.CachePut
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@CacheConfig(cacheNames = [UserCache.CACHE_NAME])
+@Component
+class UserCache : CustomRedisCacheConfiguration.CustomRedisCacheConfigurationBuilder() {
+
+    override val cacheName = CACHE_NAME
+    override val cacheDuration: Duration = Duration.ofHours(1L)
+    override val redisValueSerializer = JdkSerializationRedisSerializer()
+
+    @Cacheable(key = "{ #userId }")
+    fun get(userId: Long): User? {
+        return null
+    }
+
+    @CachePut(key = "{ #user.id }")
+    fun put(user: User): User {
+        return user
+    }
+
+    companion object {
+
+        const val CACHE_NAME = "USER"
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/VideoCache.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/VideoCache.kt
@@ -1,0 +1,54 @@
+package com.github.wonsim02.examples.rediscacheusinghash.cache
+
+import com.github.wonsim02.examples.rediscacheusinghash.config.CustomRedisCacheConfiguration
+import com.github.wonsim02.examples.rediscacheusinghash.model.Video
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.CachePut
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.redis.cache.CacheKeyPrefix
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@CacheConfig(cacheNames = [VideoCache.CACHE_NAME])
+@Component
+class VideoCache(
+    cacheKeyPrefix: CacheKeyPrefix,
+    private val redisTemplate: RedisTemplate<String, ByteArray>,
+) : CustomRedisCacheConfiguration.CustomRedisCacheConfigurationBuilder() {
+
+    override val cacheName = CACHE_NAME
+    override val cacheDuration: Duration = Duration.ofHours(1L)
+    override val redisValueSerializer = JdkSerializationRedisSerializer()
+
+    private val prefix: String = cacheKeyPrefix.compute(CACHE_NAME)
+
+    @Cacheable(key = "{ #videoId }")
+    fun get(videoId: Long): Video? {
+        return null
+    }
+
+    @CachePut(key = "{ #video.id }")
+    fun put(video: Video): Video {
+        return video
+    }
+
+    fun multiGet(videoIds: Collection<Long>): Map<Long, Video> {
+        if (videoIds.isEmpty()) return mapOf()
+
+        val cacheKeys = videoIds.map { "$prefix$it" }
+        return redisTemplate
+            .opsForValue()
+            .multiGet(cacheKeys)
+            ?.asSequence()
+            ?.mapNotNull { redisValueSerializer.deserialize(it) as? Video }
+            ?.associateBy { it.id }
+            ?: mapOf()
+    }
+
+    companion object {
+
+        const val CACHE_NAME = "VIDEO"
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/WatchHistoryCountsCache.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/WatchHistoryCountsCache.kt
@@ -1,0 +1,62 @@
+package com.github.wonsim02.examples.rediscacheusinghash.cache
+
+import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchHistoryCounts
+import org.springframework.data.redis.cache.CacheKeyPrefix
+import org.springframework.data.redis.core.RedisTemplate
+import java.io.Serializable
+import java.time.Duration
+
+class WatchHistoryCountsCache(
+    cacheKeyPrefix: CacheKeyPrefix,
+    private val redisTemplate: RedisTemplate<String, ByteArray>,
+) {
+
+    private val cacheDuration: Duration = Duration.ofHours(1L)
+    private val prefix: String = cacheKeyPrefix.compute(CACHE_NAME)
+
+    fun getByUserId(userId: Long): ByUserId {
+        return ByUserId("$prefix$userId")
+    }
+
+    fun evictByUserId(userId: Long) {
+        redisTemplate.delete("$prefix$userId")
+    }
+
+    inner class ByUserId(
+        private val cacheKey: String,
+    ) {
+
+        fun get(videoIds: Collection<Long>): WatchHistoryCounts {
+            if (videoIds.isEmpty()) return mapOf()
+
+            return redisTemplate
+                .opsForHash<Long, WatchHistoryCountsEntry>()
+                .multiGet(cacheKey, videoIds)
+                .asSequence()
+                .filterNotNull()
+                .associate { it.videoId to it.count }
+        }
+
+        fun put(watchHistoryCounts: WatchHistoryCounts) {
+            if (watchHistoryCounts.isEmpty()) return
+            val entries = watchHistoryCounts.mapValues { (videoId, count) ->
+                WatchHistoryCountsEntry(videoId = videoId, count = count)
+            }
+
+            redisTemplate
+                .opsForHash<Long, WatchHistoryCountsEntry>()
+                .putAll(cacheKey, entries)
+            redisTemplate.expire(cacheKey, cacheDuration)
+        }
+    }
+
+    data class WatchHistoryCountsEntry(
+        val videoId: Long,
+        val count: Long,
+    ) : Serializable
+
+    companion object {
+
+        const val CACHE_NAME = "WATCH_HISTORY_COUNTS"
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/WatchedVideosCountsCache.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/cache/WatchedVideosCountsCache.kt
@@ -1,12 +1,12 @@
 package com.github.wonsim02.examples.rediscacheusinghash.cache
 
-import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchHistoryCounts
+import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchedVideosCounts
 import org.springframework.data.redis.cache.CacheKeyPrefix
 import org.springframework.data.redis.core.RedisTemplate
 import java.io.Serializable
 import java.time.Duration
 
-class WatchHistoryCountsCache(
+class WatchedVideosCountsCache(
     cacheKeyPrefix: CacheKeyPrefix,
     private val redisTemplate: RedisTemplate<String, ByteArray>,
 ) {
@@ -26,33 +26,33 @@ class WatchHistoryCountsCache(
         private val cacheKey: String,
     ) {
 
-        fun get(videoIds: Collection<Long>): WatchHistoryCounts {
-            if (videoIds.isEmpty()) return mapOf()
+        fun get(playListIds: Collection<Long>): WatchedVideosCounts {
+            if (playListIds.isEmpty()) return mapOf()
 
             return redisTemplate
-                .opsForHash<Long, WatchHistoryCountsEntry>()
-                .multiGet(cacheKey, videoIds)
+                .opsForHash<Long, WatchedVideosCountsEntry>()
+                .multiGet(cacheKey, playListIds)
                 .asSequence()
                 .filterNotNull()
-                .associate { it.videoId to it.count }
+                .associate { it.playListId to it.count }
         }
 
-        fun put(watchHistoryCounts: WatchHistoryCounts) {
+        fun put(watchHistoryCounts: WatchedVideosCounts) {
             if (watchHistoryCounts.isEmpty()) return
-            val entries = watchHistoryCounts.mapValues { (videoId, count) ->
-                WatchHistoryCountsEntry(videoId = videoId, count = count)
+            val entries = watchHistoryCounts.mapValues { (playListId, count) ->
+                WatchedVideosCountsEntry(playListId = playListId, count = count)
             }
 
             redisTemplate
-                .opsForHash<Long, WatchHistoryCountsEntry>()
+                .opsForHash<Long, WatchedVideosCountsEntry>()
                 .putAll(cacheKey, entries)
             redisTemplate.expire(cacheKey, cacheDuration)
         }
     }
 
-    data class WatchHistoryCountsEntry(
-        val videoId: Long,
-        val count: Long,
+    data class WatchedVideosCountsEntry(
+        val playListId: Long,
+        val count: Int,
     ) : Serializable
 
     companion object {

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/CustomRedisCacheConfiguration.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/CustomRedisCacheConfiguration.kt
@@ -1,0 +1,69 @@
+package com.github.wonsim02.examples.rediscacheusinghash.config
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.CacheKeyPrefix
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.RedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CustomRedisCacheConfiguration {
+
+    @Bean
+    fun cacheKeyPrefix(): CacheKeyPrefix {
+        return CacheKeyPrefix { name -> "$name$SEPARATOR" }
+    }
+
+    @Bean
+    fun redisCacheManagerBuilderCustomizer(
+        customRedisCacheConfigurationBuilders: List<CustomRedisCacheConfigurationBuilder>,
+        cacheKeyPrefix: CacheKeyPrefix,
+    ): RedisCacheManagerBuilderCustomizer {
+        return RedisCacheManagerBuilderCustomizer { builder ->
+            customRedisCacheConfigurationBuilders.forEach {
+                it.configureRedisCacheManagerBuilder(builder, cacheKeyPrefix)
+            }
+        }
+    }
+
+    abstract class CustomRedisCacheConfigurationBuilder {
+
+        abstract val cacheName: String
+        abstract val cacheDuration: Duration
+        abstract val redisValueSerializer: RedisSerializer<*>
+
+        private fun buildCacheConfiguration(
+            cacheKeyPrefix: CacheKeyPrefix,
+        ): RedisCacheConfiguration {
+            return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(cacheDuration)
+                .serializeValuesWith(
+                    RedisSerializationContext
+                        .SerializationPair
+                        .fromSerializer(redisValueSerializer)
+                )
+                .computePrefixWith(cacheKeyPrefix)
+        }
+
+        fun configureRedisCacheManagerBuilder(
+            builder: RedisCacheManager.RedisCacheManagerBuilder,
+            cacheKeyPrefix: CacheKeyPrefix,
+        ): RedisCacheManager.RedisCacheManagerBuilder {
+            return builder.withCacheConfiguration(
+                cacheName,
+                buildCacheConfiguration(cacheKeyPrefix),
+            )
+        }
+    }
+
+    companion object {
+
+        const val SEPARATOR = "::"
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/UserIdHeaderParameterConfiguration.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/UserIdHeaderParameterConfiguration.kt
@@ -1,0 +1,74 @@
+package com.github.wonsim02.examples.rediscacheusinghash.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import kotlin.jvm.Throws
+
+@Configuration
+class UserIdHeaderParameterConfiguration {
+
+    @Bean
+    fun requestContext(): UserRequestContext = UserRequestContext()
+
+    @Bean
+    fun userRequestContextFilter(
+        userRequestContext: UserRequestContext,
+    ): OncePerRequestFilter = object : OncePerRequestFilter() {
+
+        override fun doFilterInternal(
+            request: HttpServletRequest,
+            response: HttpServletResponse,
+            filterChain: FilterChain,
+        ) {
+            val userId = request.getHeader(USER_ID_HEADER)?.toLong()
+            if (userId != null) { userRequestContext.userId = userId }
+
+            try {
+                filterChain.doFilter(request, response)
+            } catch (t: Throwable) {
+                logger.error("Handle exception", t)
+                throw t
+            } finally {
+                userRequestContext.clear()
+            }
+        }
+    }
+
+    class UserRequestContext {
+
+        private val _userId: ThreadLocal<Long?> = ThreadLocal.withInitial { null }
+
+        @get:Throws(UserIdNotSetException::class)
+        var userId: Long
+            get() = _userId.get() ?: throw UserIdNotSetException()
+            set(value) { _userId.set(value) }
+
+        fun clear() {
+            _userId.remove()
+        }
+
+        class UserIdNotSetException : RuntimeException("\"$USER_ID_HEADER\" header not set.")
+    }
+
+    @RestControllerAdvice
+    class UserIdNotSetExceptionHandler : ResponseEntityExceptionHandler() {
+
+        @ExceptionHandler(UserRequestContext.UserIdNotSetException::class)
+        fun handleException(ex: UserRequestContext.UserIdNotSetException): ResponseEntity<String> {
+            return ResponseEntity.badRequest().body(ex.message)
+        }
+    }
+
+    companion object {
+
+        const val USER_ID_HEADER = "x-user-id"
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/WatchHistoryCountCacheConfiguration.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/WatchHistoryCountCacheConfiguration.kt
@@ -1,0 +1,31 @@
+package com.github.wonsim02.examples.rediscacheusinghash.config
+
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchHistoryCountsCache
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.CacheKeyPrefix
+import org.springframework.data.redis.core.RedisTemplate
+
+@Configuration
+@ConditionalOnProperty(
+    prefix = WatchHistoryCountCacheConfiguration.WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX,
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class WatchHistoryCountCacheConfiguration {
+
+    @Bean
+    fun watchHistoryCountsCache(
+        cacheKeyPrefix: CacheKeyPrefix,
+        redisTemplate: RedisTemplate<String, ByteArray>,
+    ): WatchHistoryCountsCache {
+        return WatchHistoryCountsCache(cacheKeyPrefix, redisTemplate)
+    }
+
+    companion object {
+
+        const val WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX = "com.github.wonsim02.examples.redis-cache-using-hash.watch-history-counts-cache"
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/WatchedVideosCountCacheConfiguration.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/WatchedVideosCountCacheConfiguration.kt
@@ -1,6 +1,6 @@
 package com.github.wonsim02.examples.rediscacheusinghash.config
 
-import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchHistoryCountsCache
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchedVideosCountsCache
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -9,23 +9,23 @@ import org.springframework.data.redis.core.RedisTemplate
 
 @Configuration
 @ConditionalOnProperty(
-    prefix = WatchHistoryCountCacheConfiguration.WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX,
+    prefix = WatchedVideosCountCacheConfiguration.WATCHED_VIDEOS_COUNT_CACHE_PROPERTY_PREFIX,
     name = ["enabled"],
     havingValue = "true",
     matchIfMissing = false,
 )
-class WatchHistoryCountCacheConfiguration {
+class WatchedVideosCountCacheConfiguration {
 
     @Bean
-    fun watchHistoryCountsCache(
+    fun watchedVideosCountsCache(
         cacheKeyPrefix: CacheKeyPrefix,
         redisTemplate: RedisTemplate<String, ByteArray>,
-    ): WatchHistoryCountsCache {
-        return WatchHistoryCountsCache(cacheKeyPrefix, redisTemplate)
+    ): WatchedVideosCountsCache {
+        return WatchedVideosCountsCache(cacheKeyPrefix, redisTemplate)
     }
 
     companion object {
 
-        const val WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX = "com.github.wonsim02.examples.redis-cache-using-hash.watch-history-counts-cache"
+        const val WATCHED_VIDEOS_COUNT_CACHE_PROPERTY_PREFIX = "com.github.wonsim02.examples.redis-cache-using-hash.watched-videos-counts-cache"
     }
 }

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/controller/RedisCacheUsingHashController.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/controller/RedisCacheUsingHashController.kt
@@ -1,0 +1,43 @@
+package com.github.wonsim02.examples.rediscacheusinghash.controller
+
+import com.github.wonsim02.examples.rediscacheusinghash.config.UserIdHeaderParameterConfiguration
+import com.github.wonsim02.examples.rediscacheusinghash.dto.PlayListWithDetails
+import com.github.wonsim02.examples.rediscacheusinghash.model.WatchHistory
+import com.github.wonsim02.examples.rediscacheusinghash.service.PlayListService
+import com.github.wonsim02.examples.rediscacheusinghash.service.WatchHistoryService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class RedisCacheUsingHashController(
+    private val playListService: PlayListService,
+    private val userRequestContext: UserIdHeaderParameterConfiguration.UserRequestContext,
+    private val watchHistoryService: WatchHistoryService,
+) {
+
+    @GetMapping("/playlists")
+    fun listPlayLists(
+        @RequestParam("cursor", required = false) cursor: Long?,
+        @RequestParam("limit", required = true) limit: Long,
+    ): ResponseEntity<ListPlayListsResponse> {
+        val userId = userRequestContext.userId
+        val playLists = playListService.list(userId, cursor, limit)
+
+        return ResponseEntity.ok(ListPlayListsResponse(playLists))
+    }
+
+    @PutMapping("/watch-histories")
+    fun createWatchHistory(
+        @RequestParam("videoId") videoId: Long,
+    ): ResponseEntity<WatchHistory> {
+        val userId = userRequestContext.userId
+        val watchHistory = watchHistoryService.create(userId, videoId)
+
+        return ResponseEntity.ok(watchHistory)
+    }
+
+    data class ListPlayListsResponse(val playLists: List<PlayListWithDetails>)
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/controller/ServiceExceptionHandler.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/controller/ServiceExceptionHandler.kt
@@ -1,0 +1,31 @@
+package com.github.wonsim02.examples.rediscacheusinghash.controller
+
+import com.github.wonsim02.examples.rediscacheusinghash.service.PlayListService
+import com.github.wonsim02.examples.rediscacheusinghash.service.WatchHistoryService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+@RestControllerAdvice
+class ServiceExceptionHandler : ResponseEntityExceptionHandler() {
+
+    @ExceptionHandler(PlayListService.InvalidUserIdException::class)
+    fun handleException(ex: PlayListService.InvalidUserIdException): ResponseEntity<String> {
+        return buildBadRequest(ex)
+    }
+
+    @ExceptionHandler(WatchHistoryService.InvalidUserIdException::class)
+    fun handleException(ex: WatchHistoryService.InvalidUserIdException): ResponseEntity<String> {
+        return buildBadRequest(ex)
+    }
+
+    @ExceptionHandler(WatchHistoryService.InvalidVideoIdException::class)
+    fun handleException(ex: WatchHistoryService.InvalidVideoIdException): ResponseEntity<String> {
+        return buildBadRequest(ex)
+    }
+
+    private fun buildBadRequest(ex: Throwable): ResponseEntity<String> {
+        return ResponseEntity.badRequest().body(ex.message)
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/PlayListWithDetails.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/PlayListWithDetails.kt
@@ -1,0 +1,27 @@
+package com.github.wonsim02.examples.rediscacheusinghash.dto
+
+import com.github.wonsim02.examples.rediscacheusinghash.model.PlayList
+import com.github.wonsim02.examples.rediscacheusinghash.model.Video
+
+data class PlayListWithDetails(
+    val id: Long,
+    val title: String,
+    val videos: List<Video>,
+    val watchedVideosCount: Int,
+) {
+
+    constructor(
+        playList: PlayList,
+        videoMap: Map<Long, Video>,
+        watchHistoryCounts: WatchHistoryCounts,
+    ) : this(
+        id = playList.id,
+        title = playList.title,
+        videos = playList
+            .videoIds
+            .map { videoMap[it] ?: throw NoSuchElementException() },
+        watchedVideosCount = playList
+            .videoIds
+            .count { videoId -> watchHistoryCounts[videoId]?.let { it > 0 } ?: false },
+    )
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/PlayListWithDetails.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/PlayListWithDetails.kt
@@ -13,15 +13,13 @@ data class PlayListWithDetails(
     constructor(
         playList: PlayList,
         videoMap: Map<Long, Video>,
-        watchHistoryCounts: WatchHistoryCounts,
+        watchedVideosCounts: WatchedVideosCounts,
     ) : this(
         id = playList.id,
         title = playList.title,
         videos = playList
             .videoIds
             .map { videoMap[it] ?: throw NoSuchElementException() },
-        watchedVideosCount = playList
-            .videoIds
-            .count { videoId -> watchHistoryCounts[videoId]?.let { it > 0 } ?: false },
+        watchedVideosCount = watchedVideosCounts[playList.id] ?: 0,
     )
 }

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/WatchHistoryCounts.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/WatchHistoryCounts.kt
@@ -1,0 +1,3 @@
+package com.github.wonsim02.examples.rediscacheusinghash.dto
+
+typealias WatchHistoryCounts = Map<Long /* video ID */, Long /* count */>

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/WatchedVideosCounts.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/dto/WatchedVideosCounts.kt
@@ -1,0 +1,3 @@
+package com.github.wonsim02.examples.rediscacheusinghash.dto
+
+typealias WatchedVideosCounts = Map<Long /* play list ID */, Int /* count */>

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaPlayListEntity.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaPlayListEntity.kt
@@ -1,0 +1,45 @@
+package com.github.wonsim02.examples.rediscacheusinghash.entity
+
+import com.github.wonsim02.examples.rediscacheusinghash.model.PlayList
+import com.vladmihalcea.hibernate.type.array.ListArrayType
+import org.hibernate.annotations.Type
+import org.hibernate.annotations.TypeDef
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity(name = "JpaPlayListEntity")
+@Table(
+    schema = "public",
+    name = "play_list",
+)
+@TypeDef(
+    name = "list-array",
+    typeClass = ListArrayType::class,
+)
+class JpaPlayListEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "title")
+    val title: String,
+
+    videoIds: List<Long>,
+) {
+
+    @Column(name = "video_ids", columnDefinition = "bigint[]")
+    @Type(type = "list-array")
+    val videoIds: List<Long> = videoIds.distinct()
+
+    fun toModel(): PlayList {
+        return PlayList(
+            id = id,
+            title = title,
+            videoIds = videoIds,
+        )
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaUserEntity.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaUserEntity.kt
@@ -1,0 +1,31 @@
+package com.github.wonsim02.examples.rediscacheusinghash.entity
+
+import com.github.wonsim02.examples.rediscacheusinghash.model.User
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity(name = "JpaUserEntity")
+@Table(
+    schema = "public",
+    name = "user",
+)
+class JpaUserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "name")
+    val name: String,
+) {
+
+    fun toModel(): User {
+        return User(
+            id = id,
+            name = name,
+        )
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaVideoEntity.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaVideoEntity.kt
@@ -1,0 +1,31 @@
+package com.github.wonsim02.examples.rediscacheusinghash.entity
+
+import com.github.wonsim02.examples.rediscacheusinghash.model.Video
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity(name = "JpaVideoEntity")
+@Table(
+    schema = "public",
+    name = "video",
+)
+class JpaVideoEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "title")
+    val title: String,
+) {
+
+    fun toModel(): Video {
+        return Video(
+            id = id,
+            title = title,
+        )
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaWatchHistoryEntity.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/entity/JpaWatchHistoryEntity.kt
@@ -1,0 +1,35 @@
+package com.github.wonsim02.examples.rediscacheusinghash.entity
+
+import com.github.wonsim02.examples.rediscacheusinghash.model.WatchHistory
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity(name = "JpaWatchHistoryEntity")
+@Table(
+    schema = "public",
+    name = "watch_history",
+)
+class JpaWatchHistoryEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "video_id")
+    val videoId: Long,
+) {
+
+    fun toModel(): WatchHistory {
+        return WatchHistory(
+            id = id,
+            userId = userId,
+            videoId = videoId,
+        )
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/PlayList.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/PlayList.kt
@@ -1,0 +1,9 @@
+package com.github.wonsim02.examples.rediscacheusinghash.model
+
+import java.io.Serializable
+
+data class PlayList(
+    val id: Long,
+    val title: String,
+    val videoIds: List<Long>,
+) : Serializable

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/User.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/User.kt
@@ -1,0 +1,8 @@
+package com.github.wonsim02.examples.rediscacheusinghash.model
+
+import java.io.Serializable
+
+data class User(
+    val id: Long,
+    val name: String,
+) : Serializable

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/Video.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/Video.kt
@@ -1,0 +1,8 @@
+package com.github.wonsim02.examples.rediscacheusinghash.model
+
+import java.io.Serializable
+
+data class Video(
+    val id: Long,
+    val title: String,
+) : Serializable

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/WatchHistory.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/model/WatchHistory.kt
@@ -1,0 +1,9 @@
+package com.github.wonsim02.examples.rediscacheusinghash.model
+
+import java.io.Serializable
+
+data class WatchHistory(
+    val id: Long,
+    val userId: Long,
+    val videoId: Long,
+) : Serializable

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/PlayListRepository.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/PlayListRepository.kt
@@ -1,0 +1,38 @@
+package com.github.wonsim02.examples.rediscacheusinghash.repository
+
+import com.github.womsim02.common.util.applyIfNotNull
+import com.github.wonsim02.examples.rediscacheusinghash.entity.JpaPlayListEntity
+import com.github.wonsim02.examples.rediscacheusinghash.entity.QJpaPlayListEntity.jpaPlayListEntity
+import com.github.wonsim02.examples.rediscacheusinghash.model.PlayList
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import javax.transaction.Transactional
+
+@Repository
+class PlayListRepository(
+    private val jpaQueryFactory: JPAQueryFactory,
+) {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Transactional
+    fun create(title: String, videoIds: List<Long>): PlayList {
+        val entity = JpaPlayListEntity(title = title, videoIds = videoIds)
+        entityManager.persist(entity)
+        return entity.toModel()
+    }
+
+    fun list(cursor: Long?, limit: Long): List<PlayList> {
+        if (limit <= 0L) return listOf()
+
+        return jpaQueryFactory
+            .selectFrom(jpaPlayListEntity)
+            .applyIfNotNull(cursor) { where(jpaPlayListEntity.id.gt(it)) }
+            .orderBy(jpaPlayListEntity.id.asc())
+            .fetch()
+            .map { it.toModel() }
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/UserRepository.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/UserRepository.kt
@@ -1,0 +1,28 @@
+package com.github.wonsim02.examples.rediscacheusinghash.repository
+
+import com.github.wonsim02.examples.rediscacheusinghash.entity.JpaUserEntity
+import com.github.wonsim02.examples.rediscacheusinghash.model.User
+import org.springframework.stereotype.Repository
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import javax.transaction.Transactional
+
+@Repository
+class UserRepository {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Transactional
+    fun create(name: String): User {
+        val entity = JpaUserEntity(name = name)
+        entityManager.persist(entity)
+        return entity.toModel()
+    }
+
+    fun findById(id: Long): User? {
+        return entityManager
+            .find(JpaUserEntity::class.java, id)
+            ?.toModel()
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/VideoRepository.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/VideoRepository.kt
@@ -1,0 +1,40 @@
+package com.github.wonsim02.examples.rediscacheusinghash.repository
+
+import com.github.wonsim02.examples.rediscacheusinghash.entity.JpaVideoEntity
+import com.github.wonsim02.examples.rediscacheusinghash.entity.QJpaVideoEntity.jpaVideoEntity
+import com.github.wonsim02.examples.rediscacheusinghash.model.Video
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import javax.transaction.Transactional
+
+@Repository
+class VideoRepository(
+    private val jpaQueryFactory: JPAQueryFactory,
+) {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Transactional
+    fun create(title: String): Video {
+        val entity = JpaVideoEntity(title = title)
+        entityManager.persist(entity)
+        return entity.toModel()
+    }
+
+    fun existsById(id: Long): Boolean {
+        return entityManager.find(JpaVideoEntity::class.java, id) != null
+    }
+
+    fun fetch(ids: Collection<Long>): Map<Long, Video> {
+        if (ids.isEmpty()) return mapOf()
+
+        return jpaQueryFactory
+            .selectFrom(jpaVideoEntity)
+            .where(jpaVideoEntity.id.`in`(ids))
+            .fetch()
+            .associate { it.id to it.toModel() }
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/WatchHistoryRepository.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/repository/WatchHistoryRepository.kt
@@ -1,0 +1,57 @@
+package com.github.wonsim02.examples.rediscacheusinghash.repository
+
+import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchHistoryCounts
+import com.github.wonsim02.examples.rediscacheusinghash.entity.JpaWatchHistoryEntity
+import com.github.wonsim02.examples.rediscacheusinghash.entity.QJpaWatchHistoryEntity.jpaWatchHistoryEntity
+import com.github.wonsim02.examples.rediscacheusinghash.model.WatchHistory
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import javax.transaction.Transactional
+
+@Repository
+class WatchHistoryRepository(
+    private val jpaQueryFactory: JPAQueryFactory,
+) {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Transactional
+    fun create(userId: Long, videoId: Long): WatchHistory {
+        val entity = JpaWatchHistoryEntity(userId = userId, videoId = videoId)
+        entityManager.persist(entity)
+        return entity.toModel()
+    }
+
+    fun countByUserIdAndVideoIds(
+        userId: Long,
+        videoIds: Collection<Long>,
+    ): WatchHistoryCounts {
+        if (videoIds.isEmpty()) return mapOf()
+
+        return jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    VideoIdAndCount::class.java,
+                    jpaWatchHistoryEntity.videoId,
+                    jpaWatchHistoryEntity.count(),
+                )
+            )
+            .from(jpaWatchHistoryEntity)
+            .where(jpaWatchHistoryEntity.userId.eq(userId))
+            .where(jpaWatchHistoryEntity.videoId.`in`(videoIds))
+            .groupBy(jpaWatchHistoryEntity.videoId)
+            .fetch()
+            .asSequence()
+            .mapNotNull { it.count?.to(it.videoId) }
+            .associate { it.second to it.first }
+    }
+
+    data class VideoIdAndCount(
+        val videoId: Long,
+        val count: Long?,
+    )
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/PlayListService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/PlayListService.kt
@@ -87,5 +87,5 @@ class PlayListService(
         }
     }
 
-    class InvalidUserIdException(userId: Long) : RuntimeException("Invalid userId=$userId recevied.")
+    class InvalidUserIdException(userId: Long) : RuntimeException("Invalid userId=$userId received.")
 }

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/PlayListService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/PlayListService.kt
@@ -1,0 +1,38 @@
+package com.github.wonsim02.examples.rediscacheusinghash.service
+
+import com.github.wonsim02.examples.rediscacheusinghash.dto.PlayListWithDetails
+import com.github.wonsim02.examples.rediscacheusinghash.repository.PlayListRepository
+import org.springframework.stereotype.Service
+
+@Service
+class PlayListService(
+    private val playListRepository: PlayListRepository,
+    private val videoService: VideoService,
+    private val watchHistoryService: WatchHistoryService,
+) {
+
+    @Throws(InvalidUserIdException::class)
+    fun list(
+        userId: Long,
+        cursor: Long?,
+        limit: Long,
+    ): List<PlayListWithDetails> {
+        val playLists = playListRepository.list(cursor, limit)
+        if (playLists.isEmpty()) return listOf()
+
+        val allVideoIds = playLists.flatMap { it.videoIds }
+        val videoMap = videoService.fetch(videoIds = allVideoIds)
+        val watchHistoryCounts = try {
+            watchHistoryService.countByUserIdAndVideoIds(
+                userId = userId,
+                videoIds = allVideoIds,
+            )
+        } catch (t: WatchHistoryService.InvalidUserIdException) {
+            throw InvalidUserIdException(userId).initCause(t)
+        }
+
+        return playLists.map { PlayListWithDetails(it, videoMap, watchHistoryCounts) }
+    }
+
+    class InvalidUserIdException(userId: Long) : RuntimeException("Invalid userId=$userId recevied.")
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/PlayListService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/PlayListService.kt
@@ -1,6 +1,9 @@
 package com.github.wonsim02.examples.rediscacheusinghash.service
 
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchedVideosCountsCache
 import com.github.wonsim02.examples.rediscacheusinghash.dto.PlayListWithDetails
+import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchedVideosCounts
+import com.github.wonsim02.examples.rediscacheusinghash.model.PlayList
 import com.github.wonsim02.examples.rediscacheusinghash.repository.PlayListRepository
 import org.springframework.stereotype.Service
 
@@ -9,6 +12,7 @@ class PlayListService(
     private val playListRepository: PlayListRepository,
     private val videoService: VideoService,
     private val watchHistoryService: WatchHistoryService,
+    private val watchedVideosCountsCache: WatchedVideosCountsCache?,
 ) {
 
     @Throws(InvalidUserIdException::class)
@@ -20,8 +24,53 @@ class PlayListService(
         val playLists = playListRepository.list(cursor, limit)
         if (playLists.isEmpty()) return listOf()
 
+        val videoMap = videoService.fetch(videoIds = playLists.flatMap { it.videoIds })
+        val watchedVideosCounts = getWatchedVideosCounts(userId, playLists)
+
+        return playLists.map { PlayListWithDetails(it, videoMap, watchedVideosCounts) }
+    }
+
+    /**
+     * 주어진 사용자 및 [PlayList]들에 대하여 [PlayListWithDetails.watchedVideosCount] 값을 구한다.
+     * 만약 [WatchedVideosCountsCache] 빈을 주입받았으면 우선 캐시된 값을 활용한다.
+     * 이후 `watchedVideosCount`가 캐시되지 않은 [PlayList]에 대한 [WatchedVideosCounts] 값을 계산하여 이를 캐시에 저장한다.
+     * @return [WatchedVideosCounts] 캐시된 값과 새로 계산하여 캐시에 저장한 값 모두를 반환한다.
+     * @throws InvalidUserIdException 주어진 [userId]가 유효하지 않음
+     */
+    @Throws(InvalidUserIdException::class)
+    private fun getWatchedVideosCounts(
+        userId: Long,
+        playLists: List<PlayList>,
+    ): WatchedVideosCounts {
+        val cacheByUserId = watchedVideosCountsCache?.getByUserId(userId)
+        val playListIds = playLists.mapTo(mutableSetOf()) { it.id }
+
+        val cached = cacheByUserId?.get(playListIds) ?: mapOf()
+        val notCachedIds = playListIds - cached.keys
+        if (notCachedIds.isEmpty()) return cached
+
+        val toBePutInCache = calculateWatchedVideosCounts(
+            userId = userId,
+            playLists = playLists.filter { notCachedIds.contains(it.id) },
+        )
+        cacheByUserId?.put(toBePutInCache)
+
+        return cached + toBePutInCache
+    }
+
+    /**
+     * 주어진 사용자 및 [PlayList]들에 대하여 [PlayListWithDetails.watchedVideosCount] 값을 계산한다.
+     * @param userId 사용자의 ID
+     * @param playLists [PlayListWithDetails.watchedVideosCount] 값을 계산할 [PlayList] 목록
+     * @return [WatchedVideosCounts]
+     * @throws InvalidUserIdException 주어진 [userId]가 유효하지 않음
+     */
+    @Throws(InvalidUserIdException::class)
+    private fun calculateWatchedVideosCounts(
+        userId: Long,
+        playLists: List<PlayList>,
+    ): WatchedVideosCounts {
         val allVideoIds = playLists.flatMap { it.videoIds }
-        val videoMap = videoService.fetch(videoIds = allVideoIds)
         val watchHistoryCounts = try {
             watchHistoryService.countByUserIdAndVideoIds(
                 userId = userId,
@@ -31,7 +80,11 @@ class PlayListService(
             throw InvalidUserIdException(userId).initCause(t)
         }
 
-        return playLists.map { PlayListWithDetails(it, videoMap, watchHistoryCounts) }
+        return playLists.associate { playList ->
+            playList.id to playList
+                .videoIds
+                .count { videoId -> watchHistoryCounts[videoId]?.let { it > 0 } ?: false }
+        }
     }
 
     class InvalidUserIdException(userId: Long) : RuntimeException("Invalid userId=$userId recevied.")

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/UserService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/UserService.kt
@@ -1,0 +1,25 @@
+package com.github.wonsim02.examples.rediscacheusinghash.service
+
+import com.github.wonsim02.examples.rediscacheusinghash.cache.UserCache
+import com.github.wonsim02.examples.rediscacheusinghash.model.User
+import com.github.wonsim02.examples.rediscacheusinghash.repository.UserRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(
+    private val userCache: UserCache,
+    private val userRepository: UserRepository,
+) {
+
+    @Throws(UserNotFoundException::class)
+    fun getUser(userId: Long): User {
+        userCache.get(userId)?.let { return it }
+
+        return userRepository
+            .findById(userId)
+            ?.let(userCache::put)
+            ?: throw UserNotFoundException(userId)
+    }
+
+    class UserNotFoundException(userId: Long) : RuntimeException("User with id=$userId not found.")
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/VideoService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/VideoService.kt
@@ -1,0 +1,31 @@
+package com.github.wonsim02.examples.rediscacheusinghash.service
+
+import com.github.wonsim02.examples.rediscacheusinghash.cache.VideoCache
+import com.github.wonsim02.examples.rediscacheusinghash.model.Video
+import com.github.wonsim02.examples.rediscacheusinghash.repository.VideoRepository
+import org.springframework.stereotype.Service
+
+@Service
+class VideoService(
+    private val videoCache: VideoCache,
+    private val videoRepository: VideoRepository,
+) {
+
+    fun existsByVideoId(videoId: Long): Boolean {
+        if (videoCache.get(videoId) != null) return true
+        return videoRepository.existsById(videoId)
+    }
+
+    fun fetch(videoIds: Collection<Long>): Map<Long, Video> {
+        if (videoIds.isEmpty()) return mapOf()
+
+        val cached = videoCache.multiGet(videoIds)
+        val notCachedIds = videoIds.toSet() - cached.keys
+        if (notCachedIds.isEmpty()) return cached
+
+        val fromRepository = videoRepository.fetch(notCachedIds)
+        fromRepository.values.forEach(videoCache::put)
+
+        return cached + fromRepository
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/WatchHistoryService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/WatchHistoryService.kt
@@ -1,5 +1,6 @@
 package com.github.wonsim02.examples.rediscacheusinghash.service
 
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchedVideosCountsCache
 import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchHistoryCounts
 import com.github.wonsim02.examples.rediscacheusinghash.model.WatchHistory
 import com.github.wonsim02.examples.rediscacheusinghash.repository.WatchHistoryRepository
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service
 class WatchHistoryService(
     private val userService: UserService,
     private val videoService: VideoService,
+    private val watchedVideosCountsCache: WatchedVideosCountsCache?,
     private val watchHistoryRepository: WatchHistoryRepository,
 ) {
 
@@ -30,6 +32,9 @@ class WatchHistoryService(
             throw InvalidVideoIdException(videoId)
         }
 
+        // Video 하나에 대한 count가 변경되면 해당 video를 포함하는 PlayList의 watchedVideosCount 전부가 변경될 수 있으므로
+        // 해당 사용자의 모든 watchedVideosCount 캐시를 삭제한다.
+        watchedVideosCountsCache?.evictByUserId(userId)
         return watchHistoryRepository.create(userId, videoId)
     }
 

--- a/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/WatchHistoryService.kt
+++ b/examples/examples-redis-cache-using-hash/src/main/kotlin/com/github/wonsim02/examples/rediscacheusinghash/service/WatchHistoryService.kt
@@ -1,0 +1,70 @@
+package com.github.wonsim02.examples.rediscacheusinghash.service
+
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchHistoryCountsCache
+import com.github.wonsim02.examples.rediscacheusinghash.dto.WatchHistoryCounts
+import com.github.wonsim02.examples.rediscacheusinghash.model.WatchHistory
+import com.github.wonsim02.examples.rediscacheusinghash.repository.WatchHistoryRepository
+import org.springframework.stereotype.Service
+
+@Service
+class WatchHistoryService(
+    private val userService: UserService,
+    private val videoService: VideoService,
+    private val watchHistoryCountsCache: WatchHistoryCountsCache?,
+    private val watchHistoryRepository: WatchHistoryRepository,
+) {
+
+    @Throws(
+        InvalidUserIdException::class,
+        InvalidVideoIdException::class,
+    )
+    fun create(
+        userId: Long,
+        videoId: Long,
+    ): WatchHistory {
+        try {
+            userService.getUser(userId)
+        } catch (t: UserService.UserNotFoundException) {
+            throw InvalidUserIdException(userId).initCause(t)
+        }
+
+        if (!videoService.existsByVideoId(videoId)) {
+            throw InvalidVideoIdException(videoId)
+        }
+
+        watchHistoryCountsCache?.evictByUserId(userId)
+        return watchHistoryRepository.create(userId, videoId)
+    }
+
+    @Throws(InvalidUserIdException::class)
+    fun countByUserIdAndVideoIds(
+        userId: Long,
+        videoIds: Collection<Long>,
+    ): WatchHistoryCounts {
+        try {
+            userService.getUser(userId)
+        } catch (t: UserService.UserNotFoundException) {
+            throw InvalidUserIdException(userId).initCause(t)
+        }
+        if (videoIds.isEmpty()) return mapOf()
+
+        val cacheByUserId = watchHistoryCountsCache?.getByUserId(userId)
+        val cached = cacheByUserId?.get(videoIds) ?: mapOf()
+        val notCachedIds = videoIds.toSet() - cached.keys
+        if (notCachedIds.isEmpty()) return cached
+
+        val fromRepository = watchHistoryRepository.countByUserIdAndVideoIds(
+            userId = userId,
+            videoIds = notCachedIds,
+        )
+        val videoIdsWithZeroCounts = notCachedIds - fromRepository.keys
+        val toBePutInCache = fromRepository + videoIdsWithZeroCounts.associateWith { 0L }
+        cacheByUserId?.put(toBePutInCache)
+
+        return cached + fromRepository
+    }
+
+    class InvalidUserIdException(userId: Long) : RuntimeException("Invalid userId=$userId given.")
+
+    class InvalidVideoIdException(videoId: Long) : RuntimeException("Invalid videoId=$videoId given.")
+}

--- a/examples/examples-redis-cache-using-hash/src/main/resources/application.yml
+++ b/examples/examples-redis-cache-using-hash/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  cache:
+    type: redis
+  flyway:
+    schemas: public
+  main:
+    web-application-type: servlet

--- a/examples/examples-redis-cache-using-hash/src/main/resources/db/migration/V0.0.0__init.sql
+++ b/examples/examples-redis-cache-using-hash/src/main/resources/db/migration/V0.0.0__init.sql
@@ -1,0 +1,27 @@
+create schema if not exists public;
+
+create table if not exists public."user"
+(
+    id         bigserial primary key,
+    name       text        not null
+);
+
+create table if not exists public.video
+(
+    id         bigserial primary key,
+    title      text        not null
+);
+
+create table if not exists public.watch_history
+(
+    id         bigserial primary key,
+    user_id    bigint      not null,
+    video_id   bigint      not null
+);
+
+create table if not exists public.play_list
+(
+    id         bigserial primary key,
+    title      text        not null,
+    video_ids  bigint[]    not null
+);

--- a/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/ExamplesRedisCacheUsingHashTestBase.kt
+++ b/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/ExamplesRedisCacheUsingHashTestBase.kt
@@ -1,0 +1,45 @@
+package com.github.wonsim02.examples.rediscacheusinghash
+
+import com.github.wonsim02.infra.jpa.CustomPostgresqlContainer
+import com.github.wonsim02.infra.redis.CustomRedisContainer
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.ConfigurableApplicationContext
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+abstract class ExamplesRedisCacheUsingHashTestBase {
+
+    protected abstract val args: Array<out String>
+
+    protected inline fun testWithApplication(testAction: (ConfigurableApplicationContext) -> Unit) {
+        val app = runApplication<App>(
+            *postgresqlContainer.provideTestContainerProperties(),
+            *redisContainer.provideTestContainerProperties(),
+            *args,
+            "--CONF_REDIS_CLUSTERED=false",
+        )
+
+        try {
+            testAction(app)
+        } finally {
+            SpringApplication.exit(app)
+        }
+    }
+
+    companion object {
+
+        @Container
+        @JvmStatic
+        val postgresqlContainer = CustomPostgresqlContainer(
+            database = "database",
+            username = "username",
+            password = "password",
+        )
+
+        @Container
+        @JvmStatic
+        val redisContainer = CustomRedisContainer(password = "password")
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/Main.kt
+++ b/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/Main.kt
@@ -1,0 +1,23 @@
+package com.github.wonsim02.examples.rediscacheusinghash
+
+import com.github.wonsim02.infra.jpa.CustomPostgresqlContainer
+import com.github.wonsim02.infra.redis.CustomRedisContainer
+import org.springframework.boot.runApplication
+
+fun main(vararg args: String) {
+    val postgresqlContainer = CustomPostgresqlContainer(
+        database = "database",
+        username = "username",
+        password = "password",
+    )
+    val redisContainer = CustomRedisContainer(password = "password")
+
+    postgresqlContainer.start()
+    redisContainer.start()
+
+    runApplication<App>(
+        *postgresqlContainer.provideTestContainerProperties(),
+        *redisContainer.provideTestContainerProperties(),
+        "--CONF_REDIS_CLUSTERED=false",
+    )
+}

--- a/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/WatchedVideosCountsCacheConfigurationTest.kt
+++ b/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/WatchedVideosCountsCacheConfigurationTest.kt
@@ -2,10 +2,10 @@ package com.github.wonsim02.examples.rediscacheusinghash
 
 import com.fasterxml.jackson.module.kotlin.jsonMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
-import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchHistoryCountsCache
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchedVideosCountsCache
 import com.github.wonsim02.examples.rediscacheusinghash.client.RedisCacheUsingHashApiClient
 import com.github.wonsim02.examples.rediscacheusinghash.config.AddingTestDataRunner
-import com.github.wonsim02.examples.rediscacheusinghash.config.WatchHistoryCountCacheConfiguration.Companion.WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX
+import com.github.wonsim02.examples.rediscacheusinghash.config.WatchedVideosCountCacheConfiguration.Companion.WATCHED_VIDEOS_COUNT_CACHE_PROPERTY_PREFIX
 import com.github.wonsim02.examples.rediscacheusinghash.repository.WatchHistoryRepository
 import okhttp3.OkHttpClient
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,7 +19,7 @@ import kotlin.random.Random
 import kotlin.system.measureTimeMillis
 
 /**
- * [WatchHistoryCountsCache] 빈 등록 여부에 따른 성능 테스트.
+ * [WatchedVideosCountsCache] 빈 등록 여부에 따른 성능 테스트.
  * 테스트 전에 다음 사전 작업을 진행한다:
  * 1. [AddingTestDataRunner]를 통해 테스트에서 사용할 `User`, `Video` 및 `PlayList` 등록
  * 2. 랜덤 `userId` 및 `videoId`로 `WatchHistory` 행 [NUM_WATCH_HISTORIES]개 추가
@@ -35,16 +35,16 @@ import kotlin.system.measureTimeMillis
  * 2. [RedisCacheUsingHashApiClient.createWatchHistory] 응답 시간 총합
  * 3. [RedisCacheUsingHashApiClient.listPlayLists] 응답 시간 총합
  *
- * @property watchHistoryCacheEnabled [WatchHistoryCountsCache] 빈 등록 여부
+ * @property watchHistoryCacheEnabled [WatchedVideosCountsCache] 빈 등록 여부
  */
-abstract class WatchingHistoryCountsCacheConfigurationTest : ExamplesRedisCacheUsingHashTestBase() {
+abstract class WatchedVideosCountsCacheConfigurationTest : ExamplesRedisCacheUsingHashTestBase() {
 
     protected abstract val watchHistoryCacheEnabled: Boolean
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     final override val args: Array<out String>
         get() = arrayOf(
-            "--$WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX.enabled=$watchHistoryCacheEnabled",
+            "--$WATCHED_VIDEOS_COUNT_CACHE_PROPERTY_PREFIX.enabled=$watchHistoryCacheEnabled",
             "--server.port=0"
         )
 
@@ -124,12 +124,12 @@ abstract class WatchingHistoryCountsCacheConfigurationTest : ExamplesRedisCacheU
         }
     }
 
-    class Enabled : WatchingHistoryCountsCacheConfigurationTest() {
+    class Enabled : WatchedVideosCountsCacheConfigurationTest() {
 
         override val watchHistoryCacheEnabled = true
     }
 
-    class Disabled : WatchingHistoryCountsCacheConfigurationTest() {
+    class Disabled : WatchedVideosCountsCacheConfigurationTest() {
 
         override val watchHistoryCacheEnabled = false
     }

--- a/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/WatchingHistoryCountsCacheConfigurationTest.kt
+++ b/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/WatchingHistoryCountsCacheConfigurationTest.kt
@@ -1,0 +1,143 @@
+package com.github.wonsim02.examples.rediscacheusinghash
+
+import com.fasterxml.jackson.module.kotlin.jsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import com.github.wonsim02.examples.rediscacheusinghash.cache.WatchHistoryCountsCache
+import com.github.wonsim02.examples.rediscacheusinghash.client.RedisCacheUsingHashApiClient
+import com.github.wonsim02.examples.rediscacheusinghash.config.AddingTestDataRunner
+import com.github.wonsim02.examples.rediscacheusinghash.config.WatchHistoryCountCacheConfiguration.Companion.WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX
+import com.github.wonsim02.examples.rediscacheusinghash.repository.WatchHistoryRepository
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.boot.web.context.WebServerApplicationContext
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.system.measureTimeMillis
+
+/**
+ * [WatchHistoryCountsCache] 빈 등록 여부에 따른 성능 테스트.
+ * 테스트 전에 다음 사전 작업을 진행한다:
+ * 1. [AddingTestDataRunner]를 통해 테스트에서 사용할 `User`, `Video` 및 `PlayList` 등록
+ * 2. 랜덤 `userId` 및 `videoId`로 `WatchHistory` 행 [NUM_WATCH_HISTORIES]개 추가
+ *
+ * 테스트는 [RedisCacheUsingHashApiClient.createWatchHistory] 및 [RedisCacheUsingHashApiClient.listPlayLists] API를
+ * 호출하는 형식으로 진행된다. 이 때, API 호출 시나리오는 다음과 같다:
+ * 1. [RedisCacheUsingHashApiClient.createWatchHistory] API 1회 호출
+ * 2. [RedisCacheUsingHashApiClient.listPlayLists] API ([CALL_CREATE_WATCH_HISTORY_PERIOD] - 1)회 호출
+ * 3. 1과 2를 두 API 호출 횟수가 [NUM_API_CALLS]회가 될 때까지 반복
+ *
+ * 테스트 이후 다음 값을 출력한다:
+ * 1. 두 종류 API 응답 시간의 총합
+ * 2. [RedisCacheUsingHashApiClient.createWatchHistory] 응답 시간 총합
+ * 3. [RedisCacheUsingHashApiClient.listPlayLists] 응답 시간 총합
+ *
+ * @property watchHistoryCacheEnabled [WatchHistoryCountsCache] 빈 등록 여부
+ */
+abstract class WatchingHistoryCountsCacheConfigurationTest : ExamplesRedisCacheUsingHashTestBase() {
+
+    protected abstract val watchHistoryCacheEnabled: Boolean
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    final override val args: Array<out String>
+        get() = arrayOf(
+            "--$WATCH_HISTORY_COUNT_CACHE_PROPERTY_PREFIX.enabled=$watchHistoryCacheEnabled",
+            "--server.port=0"
+        )
+
+    @Test
+    fun test() = testWithApplication { app ->
+        val runner = app.getBean(AddingTestDataRunner::class.java)
+        val userId = runner.userId!!
+        val videoIds = runner.videoIds!!
+
+        val runningPort = (app as WebServerApplicationContext).webServer.port
+        val client = Retrofit.Builder()
+            .client(
+                OkHttpClient.Builder()
+                    .callTimeout(0, TimeUnit.SECONDS)
+                    .connectTimeout(0, TimeUnit.SECONDS)
+                    .readTimeout(0, TimeUnit.SECONDS)
+                    .writeTimeout(0, TimeUnit.SECONDS)
+                    .build()
+            )
+            .baseUrl("http://localhost:$runningPort")
+            .addConverterFactory(
+                JacksonConverterFactory.create(
+                    jsonMapper { addModule(kotlinModule()) }
+                )
+            )
+            .build()
+            .create(RedisCacheUsingHashApiClient::class.java)
+
+        val watchHistoryRepository = app.getBean(WatchHistoryRepository::class.java)
+        repeat(NUM_WATCH_HISTORIES) {
+            watchHistoryRepository.create(
+                userId = Random.nextLong(from = 1, until = 100),
+                videoId = videoIds.random(),
+            )
+        }
+
+        var createWatchHistoryElapsedTimeMs = 0L
+        var listPlayListsElapsedTimeMs = 0L
+        val elapsedTimeMs = measureTimeMillis {
+            repeat(NUM_API_CALLS) { index ->
+                if (index % CALL_CREATE_WATCH_HISTORY_PERIOD == 0) {
+                    createWatchHistoryElapsedTimeMs += doCreateWatchHistory(client, userId, videoIds)
+                } else {
+                    listPlayListsElapsedTimeMs += doListPlayLists(client, userId)
+                }
+            }
+        }
+
+        logger.info("Total elapsed time is {} ms.", elapsedTimeMs)
+        logger.info("Total elapsed time of createWatchHistory is {} ms.", createWatchHistoryElapsedTimeMs)
+        logger.info("Total elapsed time of listPlyLists is {} ms.", listPlayListsElapsedTimeMs)
+    }
+
+    private fun doListPlayLists(
+        client: RedisCacheUsingHashApiClient,
+        userId: Long,
+    ): Long {
+        return measureTimeMillis {
+            client
+                .listPlayLists(userId = userId, cursor = null, limit = 20L)
+                .execute()
+                .also { assertTrue(it.isSuccessful) }
+        }
+    }
+
+    private fun doCreateWatchHistory(
+        client: RedisCacheUsingHashApiClient,
+        userId: Long,
+        videoIds: Collection<Long>,
+    ): Long {
+        val selectedVideoId = videoIds.random()
+        return measureTimeMillis {
+            client
+                .createWatchHistory(userId = userId, videoId = selectedVideoId)
+                .execute()
+                .also { assertTrue(it.isSuccessful) }
+        }
+    }
+
+    class Enabled : WatchingHistoryCountsCacheConfigurationTest() {
+
+        override val watchHistoryCacheEnabled = true
+    }
+
+    class Disabled : WatchingHistoryCountsCacheConfigurationTest() {
+
+        override val watchHistoryCacheEnabled = false
+    }
+
+    companion object {
+
+        const val CALL_CREATE_WATCH_HISTORY_PERIOD = 20
+        const val NUM_API_CALLS = 20000
+        const val NUM_WATCH_HISTORIES = 100000
+    }
+}

--- a/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/client/RedisCacheUsingHashApiClient.kt
+++ b/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/client/RedisCacheUsingHashApiClient.kt
@@ -1,0 +1,29 @@
+package com.github.wonsim02.examples.rediscacheusinghash.client
+
+import com.github.wonsim02.examples.rediscacheusinghash.config.UserIdHeaderParameterConfiguration.Companion.USER_ID_HEADER
+import com.github.wonsim02.examples.rediscacheusinghash.controller.RedisCacheUsingHashController
+import com.github.wonsim02.examples.rediscacheusinghash.model.WatchHistory
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.PUT
+import retrofit2.http.Query
+
+/**
+ * [RedisCacheUsingHashController]의 API에 대한 retrofit 클라이언트.
+ */
+interface RedisCacheUsingHashApiClient {
+
+    @GET("/playlists")
+    fun listPlayLists(
+        @Header(USER_ID_HEADER) userId: Long,
+        @Query("cursor") cursor: Long?,
+        @Query("limit") limit: Long,
+    ): Call<RedisCacheUsingHashController.ListPlayListsResponse>
+
+    @PUT("/watch-histories")
+    fun createWatchHistory(
+        @Header(USER_ID_HEADER) userId: Long,
+        @Query("videoId") videoId: Long,
+    ): Call<WatchHistory>
+}

--- a/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/AddingTestDataRunner.kt
+++ b/examples/examples-redis-cache-using-hash/src/test/kotlin/com/github/wonsim02/examples/rediscacheusinghash/config/AddingTestDataRunner.kt
@@ -1,0 +1,51 @@
+package com.github.wonsim02.examples.rediscacheusinghash.config
+
+import com.github.wonsim02.examples.rediscacheusinghash.model.PlayList
+import com.github.wonsim02.examples.rediscacheusinghash.model.User
+import com.github.wonsim02.examples.rediscacheusinghash.model.Video
+import com.github.wonsim02.examples.rediscacheusinghash.repository.PlayListRepository
+import com.github.wonsim02.examples.rediscacheusinghash.repository.UserRepository
+import com.github.wonsim02.examples.rediscacheusinghash.repository.VideoRepository
+import org.springframework.boot.CommandLineRunner
+import org.springframework.stereotype.Component
+
+/**
+ * 테스트에 사용할 [User], [Video] 및 [PlayList]를 등록하는 [CommandLineRunner].
+ */
+@Component
+class AddingTestDataRunner(
+    private val playListRepository: PlayListRepository,
+    private val userRepository: UserRepository,
+    private val videoRepository: VideoRepository,
+) : CommandLineRunner {
+
+    private var _videoIds: List<Long>? = null
+    val videoIds: List<Long>? get() = _videoIds
+
+    private var _userId: Long? = null
+    val userId: Long? get() = _userId
+
+    override fun run(vararg args: String?) {
+        _userId = userRepository.create("John Doe").id
+        val createdVideoIds = (0 until NUM_VIDEOS).mapTo(mutableListOf()) { index ->
+            val title = "Video #$index"
+            videoRepository.create(title = title).id
+        }
+        _videoIds = createdVideoIds.toList()
+
+        repeat(NUM_PLAY_LISTS) { index ->
+            createdVideoIds.shuffle()
+            val selected = createdVideoIds.subList(0, 50)
+            playListRepository.create(
+                title = "PlayList #$index",
+                videoIds = selected,
+            )
+        }
+    }
+
+    companion object {
+
+        const val NUM_VIDEOS = 1000
+        const val NUM_PLAY_LISTS = 20
+    }
+}

--- a/infra-redis/src/main/kotlin/com/github/wonsim02/infra/redis/config/CustomizingRedisPropertiesConfiguration.kt
+++ b/infra-redis/src/main/kotlin/com/github/wonsim02/infra/redis/config/CustomizingRedisPropertiesConfiguration.kt
@@ -1,0 +1,37 @@
+package com.github.wonsim02.infra.redis.config
+
+import com.github.womsim02.common.spring.ProfileAwarePropertySource
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+
+/**
+ * [RedisAutoConfiguration] 이전에 [RedisProperties]를 수정하는 configuration.
+ */
+@EnableConfigurationProperties(
+    InfraRedisProperties::class,
+    RedisProperties::class,
+)
+@ProfileAwarePropertySource(
+    locations = [
+        "classpath:/infra-redis-config.yml",
+        "classpath:/infra-redis-config-*.yml",
+    ],
+)
+@AutoConfigureBefore(RedisAutoConfiguration::class)
+class CustomizingRedisPropertiesConfiguration(
+    infraRedisProperties: InfraRedisProperties,
+    redisProperties: RedisProperties,
+) {
+
+    init {
+        // `infraRedisProperties.clustered`가 `true`이면 `redisProperties.cluster` 값을 설정해 준다.
+        if (infraRedisProperties.clustered) {
+            val endpoint = redisProperties.run { "$host:$port" }
+            val cluster = RedisProperties.Cluster()
+            cluster.nodes = mutableListOf(endpoint)
+            redisProperties.cluster = cluster
+        }
+    }
+}

--- a/infra-redis/src/main/kotlin/com/github/wonsim02/infra/redis/config/InfraRedisConfiguration.kt
+++ b/infra-redis/src/main/kotlin/com/github/wonsim02/infra/redis/config/InfraRedisConfiguration.kt
@@ -1,37 +1,38 @@
 package com.github.wonsim02.infra.redis.config
 
-import com.github.womsim02.common.spring.ProfileAwarePropertySource
-import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import com.github.wonsim02.infra.redis.util.ByteArrayRedisSerializer
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties
-import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
 
-/**
- * [RedisAutoConfiguration] 이전에 [RedisProperties]를 수정하는 configuration.
- */
-@EnableConfigurationProperties(
-    InfraRedisProperties::class,
-    RedisProperties::class,
-)
-@ProfileAwarePropertySource(
-    locations = [
-        "classpath:/infra-redis-config.yml",
-        "classpath:/infra-redis-config-*.yml",
-    ],
-)
-@AutoConfigureBefore(RedisAutoConfiguration::class)
-class InfraRedisConfiguration(
-    infraRedisProperties: InfraRedisProperties,
-    redisProperties: RedisProperties,
-) {
+@Configuration
+@AutoConfigureAfter(RedisAutoConfiguration::class)
+class InfraRedisConfiguration {
 
-    init {
-        // `infraRedisProperties.clustered`가 `true`이면 `redisProperties.cluster` 값을 설정해 준다.
-        if (infraRedisProperties.clustered) {
-            val endpoint = redisProperties.run { "$host:$port" }
-            val cluster = RedisProperties.Cluster()
-            cluster.nodes = mutableListOf(endpoint)
-            redisProperties.cluster = cluster
-        }
+    @Bean(name = [BYTE_ARRAY_REDIS_TEMPLATE])
+    @ConditionalOnSingleCandidate(RedisConnectionFactory::class)
+    fun byteArrayRedisTemplate(
+        redisConnectionFactory: RedisConnectionFactory,
+    ): RedisTemplate<String, ByteArray> {
+        val template = RedisTemplate<String, ByteArray>()
+
+        template.setConnectionFactory(redisConnectionFactory)
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = ByteArrayRedisSerializer()
+        template.hashKeySerializer = JdkSerializationRedisSerializer()
+        template.hashValueSerializer = JdkSerializationRedisSerializer()
+
+        return template
+    }
+
+    companion object {
+
+        const val BYTE_ARRAY_REDIS_TEMPLATE = "byteArrayRedisTemplate"
     }
 }

--- a/infra-redis/src/main/kotlin/com/github/wonsim02/infra/redis/util/ByteArrayRedisSerializer.kt
+++ b/infra-redis/src/main/kotlin/com/github/wonsim02/infra/redis/util/ByteArrayRedisSerializer.kt
@@ -1,0 +1,14 @@
+package com.github.wonsim02.infra.redis.util
+
+import org.springframework.data.redis.serializer.RedisSerializer
+
+class ByteArrayRedisSerializer : RedisSerializer<ByteArray> {
+
+    override fun serialize(t: ByteArray?): ByteArray? {
+        return t
+    }
+
+    override fun deserialize(bytes: ByteArray?): ByteArray? {
+        return bytes
+    }
+}

--- a/infra-redis/src/main/resources/META-INF/spring.factories
+++ b/infra-redis/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.github.wonsim02.infra.redis.config.CustomizingRedisPropertiesConfiguration,\
 com.github.wonsim02.infra.redis.config.InfraRedisConfiguration

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "spring-kotlin-exercise"
 
 include(":common")
 include(":examples:examples-jpa-polymorphism")
+include(":examples:examples-redis-cache-using-hash")
 include(":examples:examples-share-row-id-sequence")
 include(":examples:examples-use-hibernate-impl")
 include(":infra-jpa")


### PR DESCRIPTION
### `mget`을 이용한 성능 최적화

Redis에서 여러 캐시 값을 가져오려 할 때 [mget](https://redis.io/docs/latest/commands/mget/) 연산을 이용하여 요청 한 번에 필요한 캐시 값을 모두 불러올 수 있게 합니다.

### `hget` 및 `hset`을 이용한 성능 최적화

다음 조건을 만족하는 상황에 대하여 [hget](https://redis.io/docs/latest/commands/hget/), [hset](https://redis.io/docs/latest/commands/hset/) 및 [del](https://redis.io/docs/latest/commands/del/) 연산을 이용하여 API 성능을 최적화합니다:

1. 한 사용자에 대하여 데이터 추가/수정 작업 하나가 해당 사용자에 대한 쿼리 결과 전부에 영향을 줄 수 있음
    - PUT `/watch-histories` API 호출로 인해 GET `/playlists` API 응답의 `PlayListWithDetails.watchedVideosCount`가 변화할 수 있음
    - `del` Redis 연산으로  PUT `/watch-histories` API 호출 시 특정 사용자에 대한 `WatchHistory` 개수 캐시를 전부 삭제할 수 있음
2. 1의 읽기 쿼리의 속도가 느림
    - `PlayListWithDetails`의 `watchedVideosCount`를 구하려면 `PlayList.videoIds`의 각 ID에 대하여 `WatchHistory`가 존재하는 지 검사해야 함
    - 테스트에서의 API 응답 시간 비교를 위하여 index를 추가하지 않은 상태